### PR TITLE
Use component name as property category.

### DIFF
--- a/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
@@ -180,11 +180,9 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
             if (aspectEngine is IpiOnPremiseEngine ipiEngine)
             {
                 return ipiEngine.Components.SelectMany(comp
-                    => comp.Properties.Select(prop =>
+                    => comp.Properties.Select(prop => new PropertyMetaData(prop)
                     {
-                        var newProp = new PropertyMetaData(prop);
-                        newProp.Category = comp.Name;
-                        return newProp;
+                        Category = comp.Name
                     }));
             }
             return aspectEngine.Properties.Select(prop => new PropertyMetaData(prop));


### PR DESCRIPTION
### Changes

- Use component name as property category for IPI (in minAPI example).
