### PR TITLE
Remove explicit dependency on `FiftyOne.Pipeline.Core`.

### DIFF
--- a/Examples/FiftyOne.IpIntelligence.Examples.Cloud/FiftyOne.IpIntelligence.Examples.Cloud.csproj
+++ b/Examples/FiftyOne.IpIntelligence.Examples.Cloud/FiftyOne.IpIntelligence.Examples.Cloud.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="FiftyOne.IpIntelligence.Cloud" Version="4.5.0-alpha.144" />
     <PackageReference Include="FiftyOne.IpIntelligence.Shared" Version="4.5.0-alpha.144" />
-    <PackageReference Include="FiftyOne.Pipeline.Core" Version="4.5.0-alpha.35" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Changes

- Remove explicit dependency on `FiftyOne.Pipeline.Core`.

### Why

- https://github.com/51Degrees/ip-intelligence-dotnet/actions/runs/18381806541/job/52387929352