### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/Examples/Cloud/GetAllProperties-Console/Program.cs
+++ b/Examples/Cloud/GetAllProperties-Console/Program.cs
@@ -38,7 +38,7 @@ using System.Linq;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GetAllProperties-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 /// </summary>
 namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
 {
@@ -160,8 +160,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Optional custom cloud endpoint via env var. If unset, the SDK
             // defaults to cloud.51degrees.com.

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -48,7 +48,7 @@ using System.Text;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -215,8 +215,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Load the configuration file
             var config = new ConfigurationBuilder()

--- a/Examples/Cloud/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/GettingStarted-Web/Program.cs
@@ -133,8 +133,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedWeb
                 var resourceKeyConfigKey = $"PipelineOptions:Elements:{cloudEngineIndex}" +
                     $":BuildParameters:ResourceKey";
 
-                string resourceKey = Environment.GetEnvironmentVariable(
-                        ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                string resourceKey = ExampleUtils.GetResourceKeyFromEnv();
 
                 if (string.IsNullOrEmpty(resourceKey) == false)
                 {

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -50,7 +50,7 @@ using FiftyOne.Pipeline.Engines.Data;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Metadata-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -145,8 +145,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Metadata
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
@@ -50,7 +50,7 @@ using FiftyOne.DeviceDetection.Cloud.FlowElements;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -282,8 +282,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
             // Use the command line args to get the resource key if present.
             // Otherwise, get it from the environment variable.
             string resourceKey = args.Length > 0 ? args[0] :
-                Environment.GetEnvironmentVariable(
-                    ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                ExampleUtils.GetResourceKeyFromEnv();
 
             // Load the configuration file
             var config = new ConfigurationBuilder()

--- a/Examples/Cloud/Mixed/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/Mixed/GettingStarted-Web/Program.cs
@@ -110,8 +110,7 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.Cloud.GettingStartedWeb
                 var resourceKeyConfigKey = $"PipelineOptions:Elements:{cloudEngineIndex}" +
                     $":BuildParameters:ResourceKey";
 
-                string resourceKey = Environment.GetEnvironmentVariable(
-                        ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+                string resourceKey = ExampleUtils.GetResourceKeyFromEnv();
 
                 if (string.IsNullOrEmpty(resourceKey) == false)
                 {

--- a/Examples/FiftyOne.IpIntelligence.Examples/Constants.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/Constants.cs
@@ -48,9 +48,19 @@ namespace FiftyOne.IpIntelligence.Examples
         public const string LICENSE_KEY_ENV_VAR = "IPINTELLIGENCELICENSEKEY_DOTNET";
 
         /// <summary>
-        /// Environment variable key for the data file to use for the tests.
+        /// Environment variable key used to supply an explicit path to the
+        /// IP Intelligence data file. This aligned name is checked first,
+        /// before any legacy variable names.
         /// </summary>
-        public const string IP_INTELLIGENCE_DATA_FILE_ENV_VAR = "IPINTELLIGENCEDATAFILE";
+        public const string IP_INTELLIGENCE_DATA_FILE_ENV_VAR = "51DEGREES_IPI_PATH";
+
+        /// <summary>
+        /// Legacy environment variable key used to supply an explicit path to
+        /// the IP Intelligence data file. Retained for backwards
+        /// compatibility and checked when
+        /// <see cref="IP_INTELLIGENCE_DATA_FILE_ENV_VAR"/> is not set.
+        /// </summary>
+        public const string LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR = "IPINTELLIGENCEDATAFILE";
 
         /// <summary>
         /// Environment variable key for the evidence file to use for the tests.

--- a/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
@@ -33,10 +33,26 @@ namespace FiftyOne.IpIntelligence.Examples
     public static class ExampleUtils
     {
         /// <summary>
-        /// The default environment variable key used to get the resource key 
-        /// to use when running cloud examples.
+        /// The default environment variable key used to get the resource key
+        /// to use when running cloud examples. This aligned name is checked
+        /// first, before any legacy variable names.
         /// </summary>
-        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "RESOURCE_KEY";
+        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
+
+        /// <summary>
+        /// The legacy environment variable key used to get the resource key
+        /// to use when running cloud examples. Retained for backwards
+        /// compatibility and checked when <see cref="CLOUD_RESOURCE_KEY_ENV_VAR"/>
+        /// is not set.
+        /// </summary>
+        public const string LEGACY_CLOUD_RESOURCE_KEY_ENV_VAR = "RESOURCE_KEY";
+
+        /// <summary>
+        /// The legacy environment variable key used by other 51Degrees
+        /// repositories to get the resource key. Retained for backwards
+        /// compatibility and checked last.
+        /// </summary>
+        public const string LEGACY_SUPER_RESOURCE_KEY_ENV_VAR = "SUPER_RESOURCE_KEY";
 
         /// <summary>
         /// The default environment variable key used to get the end point URL
@@ -198,6 +214,44 @@ namespace FiftyOne.IpIntelligence.Examples
         }
 
         /// <summary>
+        /// Get the path to an IP Intelligence data file. The environment
+        /// variables are checked first for an explicit path. The aligned
+        /// variable named by <see cref="Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR"/>
+        /// takes precedence over the legacy variable named by
+        /// <see cref="Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR"/>.
+        /// If neither is set, the folder hierarchy is searched for the
+        /// supplied file name using <see cref="FindFile(string, DirectoryInfo)"/>.
+        /// </summary>
+        /// <param name="filename">
+        /// The data file name to search for when no environment variable
+        /// supplies an explicit path.
+        /// </param>
+        /// <param name="dir">
+        /// The directory to start searching from. If not provided the current
+        /// directory is used.
+        /// </param>
+        /// <returns>
+        /// The path to the data file, or null if no file could be found.
+        /// </returns>
+        public static string FindDataFile(
+            string filename,
+            DirectoryInfo dir = null)
+        {
+            var path = Environment.GetEnvironmentVariable(
+                Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = Environment.GetEnvironmentVariable(
+                    Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                path = FindFile(filename, dir);
+            }
+            return path;
+        }
+
+        /// <summary>
         /// Display information about the data file and log warnings if specific requirements
         /// are not met.
         /// </summary>
@@ -317,6 +371,45 @@ namespace FiftyOne.IpIntelligence.Examples
             {
                 setValue(string.Empty);
             }
+        }
+
+        /// <summary>
+        /// Get the resource key from the environment. The aligned
+        /// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+        /// the legacy 'RESOURCE_KEY' and 'SUPER_RESOURCE_KEY' variables.
+        /// </summary>
+        /// <returns>
+        /// The resource key, or null if no environment variable is set.
+        /// </returns>
+        public static string GetResourceKeyFromEnv()
+        {
+            var key = Environment.GetEnvironmentVariable(
+                CLOUD_RESOURCE_KEY_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = Environment.GetEnvironmentVariable(
+                    LEGACY_CLOUD_RESOURCE_KEY_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = Environment.GetEnvironmentVariable(
+                    LEGACY_SUPER_RESOURCE_KEY_ENV_VAR);
+            }
+            return key;
+        }
+
+        /// <summary>
+        /// Get the resource key from the environment and run the action with
+        /// the value, or an empty string if no resource key is set. The
+        /// aligned '51DEGREES_RESOURCE_KEY' variable is checked first,
+        /// followed by the legacy 'RESOURCE_KEY' and 'SUPER_RESOURCE_KEY'
+        /// variables.
+        /// </summary>
+        /// <param name="setValue"></param>
+        public static void GetResourceKeyFromEnv(Action<string> setValue)
+        {
+            var key = GetResourceKeyFromEnv();
+            setValue(string.IsNullOrWhiteSpace(key) ? string.Empty : key);
         }
     }
 }

--- a/Examples/OnPremise/Compare-Console/Program.cs
+++ b/Examples/OnPremise/Compare-Console/Program.cs
@@ -647,7 +647,7 @@ public class Program
             //
             // For testing, contact us to obtain an enterprise data file:
             // https://51degrees.com/contact-us
-                Examples.ExampleUtils.FindFile(
+                Examples.ExampleUtils.FindDataFile(
                     Constants.ENTERPRISE_IPI_DATA_FILE_NAME),
 
             // Get the of the CSV file containing source truth.

--- a/Examples/OnPremise/Framework-Web/Global.asax.cs
+++ b/Examples/OnPremise/Framework-Web/Global.asax.cs
@@ -37,7 +37,7 @@ namespace Framework_Web
         {
             // Modify the configuration to a full path to the data file if the standard example is being used.
             var configFile = new FileInfo(HttpContext.Current.Server.MapPath("~/App_Data/51Degrees.json"));
-            var fullPath = ExampleUtils.FindFile("51Degrees-LiteV41.ipi", configFile.Directory);
+            var fullPath = ExampleUtils.FindDataFile("51Degrees-LiteV41.ipi", configFile.Directory);
             if (String.IsNullOrEmpty(fullPath) == false)
             {
                 var config = File.ReadAllText(configFile.FullName);

--- a/Examples/OnPremise/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Console/Program.cs
@@ -241,7 +241,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedConsole
             // Use the supplied path for the data file or find the lite file that is included
             // in the repository.
             var dataFile = args.Length > 0 ? args[0] :
-                Examples.ExampleUtils.FindFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
+                Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
             // Configure a logger to output to the console.
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -112,13 +112,31 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedWeb
             var dataFileConfigKey = $"PipelineOptions:Elements:{ipiEngineIndex}" +
                 $":BuildParameters:DataFile";
 
-            // Use the command line argument if provided, otherwise use the appsettings.json value.
-            var dataFile = dataFileOverride ?? options.GetIpiDataFile();
+            // Use the command line argument if provided. Otherwise, an explicit data file
+            // path supplied in an environment variable takes precedence over the value in
+            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
+            var dataFile = dataFileOverride;
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = options.GetIpiDataFile();
+            }
             var foundDataFile = false;
             if (string.IsNullOrEmpty(dataFile))
             {
-                throw new Exception($"A data file must be specified as a command line argument " +
-                    $"or in the appsettings.json file.");
+                throw new Exception($"A data file must be specified as a command line " +
+                    $"argument, in the appsettings.json file, or in the " +
+                    $"'{Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR}' environment variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
             // relative path. If it is relative then search for a matching file using the

--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -225,7 +225,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Metadata
                 // project space, or you may specify another file as a command line parameter.
                 //
                 // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
-                Examples.ExampleUtils.FindFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
+                Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
             File.WriteAllText("Metadata_DataFileName.txt", dataFile);
 

--- a/Examples/OnPremise/Metrics-Console/Program.cs
+++ b/Examples/OnPremise/Metrics-Console/Program.cs
@@ -1078,7 +1078,7 @@ public class Program
             // project space, or you may specify another file as a command line parameter.
             //
             // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
-            Examples.ExampleUtils.FindFile(
+            Examples.ExampleUtils.FindDataFile(
                 Constants.ENTERPRISE_IPI_DATA_FILE_NAME)
         };
 

--- a/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
@@ -429,13 +429,32 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
             var dataFileConfigKey = $"PipelineOptions:Elements:{ipiEngineIndex}" +
                                     $":BuildParameters:DataFile";
 
-            // Use the command line argument if provided, otherwise use the appsettings.json value.
-            var dataFile = dataFileOverride ?? options.GetIpiDataFile();
+            // Use the command line argument if provided. Otherwise, an explicit data file
+            // path supplied in an environment variable takes precedence over the value in
+            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
+            var dataFile = dataFileOverride;
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Examples.Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Examples.Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = options.GetIpiDataFile();
+            }
             var foundDataFile = false;
             if (string.IsNullOrEmpty(dataFile))
             {
-                throw new Exception($"A data file must be specified as a command line argument " +
-                    $"or in the appsettings.json file.");
+                throw new Exception($"A data file must be specified as a command line " +
+                    $"argument, in the appsettings.json file, or in the " +
+                    $"'{Examples.Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR}' environment " +
+                    $"variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
             // relative path. If it is relative then search for a matching file using the

--- a/Examples/OnPremise/Mixed/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-Console/Program.cs
@@ -359,12 +359,13 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedConsole
                 }
             }
             
-            // If IP intelligence file not set, try to find it in priority order
+            // If IP intelligence file not set, check the environment variables for an
+            // explicit path, then try to find it in priority order
             if (ipDataFile == null)
             {
                 foreach (var fileName in Constants.IPI_FILE_NAMES)
                 {
-                    ipDataFile = IpIntelligence.Examples.ExampleUtils.FindFile(fileName);
+                    ipDataFile = IpIntelligence.Examples.ExampleUtils.FindDataFile(fileName);
                     if (ipDataFile != null) break;
                 }
             }

--- a/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs
@@ -145,13 +145,32 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedWeb
             var dataFileConfigKey = $"PipelineOptions:Elements:{ipiEngineIndex}" +
                                     $":BuildParameters:DataFile";
 
-            // Use the command line argument if provided, otherwise use the appsettings.json value.
-            var dataFile = dataFileOverride ?? options.GetIpiDataFile();
+            // Use the command line argument if provided. Otherwise, an explicit data file
+            // path supplied in an environment variable takes precedence over the value in
+            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
+            var dataFile = dataFileOverride;
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Examples.Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Examples.Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = options.GetIpiDataFile();
+            }
             var foundDataFile = false;
             if (string.IsNullOrEmpty(dataFile))
             {
-                throw new Exception($"A data file must be specified as a command line argument " +
-                    $"or in the appsettings.json file.");
+                throw new Exception($"A data file must be specified as a command line " +
+                    $"argument, in the appsettings.json file, or in the " +
+                    $"'{Examples.Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR}' environment " +
+                    $"variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
             // relative path. If it is relative then search for a matching file using the 

--- a/Examples/OnPremise/OfflineProcessing-Console/Program.cs
+++ b/Examples/OnPremise/OfflineProcessing-Console/Program.cs
@@ -208,7 +208,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.OfflineProcessing
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
                 // https://51degrees.com/pricing
-                Examples.ExampleUtils.FindFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
+                Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
             File.WriteAllText("OfflineProcessing_DataFileName.txt", dataFile);
 

--- a/Examples/OnPremise/Performance-Console/Program.cs
+++ b/Examples/OnPremise/Performance-Console/Program.cs
@@ -377,7 +377,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Performance
                     // Note that the Lite data file is only used for illustration, and has limited accuracy
                     // and capabilities. Find out about the Enterprise data file on our pricing page:
                     // https://51degrees.com/pricing
-                    Examples.ExampleUtils.FindFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
+                    Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
                 // Do the same for the yaml evidence file.
                 var evidenceFile = options.EvidenceFile != null ? options.EvidenceFile :
                     // This file contains the 20,000 most commonly seen combinations of header values 

--- a/Examples/OnPremise/Suspicious-Console/Program.cs
+++ b/Examples/OnPremise/Suspicious-Console/Program.cs
@@ -170,7 +170,7 @@ public class Program
         // project space, or you may specify another file as a command line parameter.
         //
         // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
-        Examples.ExampleUtils.FindFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
+        Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
         File.WriteAllText("Metadata_DataFileName.txt", dataFile);
 

--- a/Examples/OnPremise/UpdateDataFile-Console/Program.cs
+++ b/Examples/OnPremise/UpdateDataFile-Console/Program.cs
@@ -61,7 +61,8 @@ using System.Net.Http;
 /// # Command Line Usage
 /// The data file path is provided via the first command line argument. Here's how it works:
 /// 
-/// 1. First argument: Data file path (optional - defaults to Constants.ENTERPRISE_IPI_DATA_FILE_NAME)
+/// 1. First argument: Data file path (optional - checks the 51DEGREES_IPI_PATH and legacy
+///    IPINTELLIGENCEDATAFILE environment variables, then defaults to Constants.ENTERPRISE_IPI_DATA_FILE_NAME)
 /// 2. Second argument: License key (optional when using --data-update-url)
 /// 3. Option: --data-update-url for custom URL
 /// 
@@ -424,13 +425,34 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
         private const string KEY_SUBMISSION_ALT_PATH = $"as an environment variable named '{Constants.LICENSE_KEY_ENV_VAR}'";
         private const string KEY_SUBMISSION_PATHS = "as the second command line argument to this program, or " + KEY_SUBMISSION_ALT_PATH;
 
+        /// <summary>
+        /// When no data file is specified on the command line, check the
+        /// environment variables for an explicit path before falling back to
+        /// the default file name.
+        /// </summary>
+        private static string DefaultDataFilePath()
+        {
+            var dataFile = Environment.GetEnvironmentVariable(
+                Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Environment.GetEnvironmentVariable(
+                    Constants.LEGACY_IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
+            }
+            if (string.IsNullOrWhiteSpace(dataFile))
+            {
+                dataFile = Constants.ENTERPRISE_IPI_DATA_FILE_NAME;
+            }
+            return dataFile;
+        }
+
         public static int Main(string[] args)
         {
             Argument<string> dataFile = new(nameof(dataFile))
             {
                 Description = "Path to IPI data file.",
                 Arity = ArgumentArity.ZeroOrOne,
-                DefaultValueFactory = _ => Constants.ENTERPRISE_IPI_DATA_FILE_NAME,
+                DefaultValueFactory = _ => DefaultDataFilePath(),
             };
             Argument<string?> licenseKey = new(nameof(licenseKey))
             {

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ Both data files should be obtained from the respective repositories:
 - Device Detection data files: [device-detection-data](https://github.com/51Degrees/device-detection-data)
 - IP Intelligence data files: [ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data)
 
+## On-premise data file
+
+The on-premise examples need an IP Intelligence data file. The examples locate
+the file in the following order:
+
+1. The "51DEGREES_IPI_PATH" environment variable, which can be set to an
+   explicit path to the data file. The legacy "IPINTELLIGENCEDATAFILE"
+   environment variable is also still supported, and is checked after
+   "51DEGREES_IPI_PATH".
+2. A search of the folder hierarchy, walking up from the working directory,
+   for the expected data file name.
+3. The free 'Lite' data file in its expected location, which is the
+   ip-intelligence-data submodule of this repository. See the Required files
+   section above on how to pull and/or generate the data files.
+
 ## 📦 NuGet Package
 
 Examples currently depend on a pre-release version of the [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence) package.  
@@ -52,6 +67,13 @@ dotnet add package FiftyOne.IpIntelligence --prerelease
 
 
 ## Cloud
+
+A resource key configured with the properties needed to run the cloud examples
+can be created for free [here](https://configure.51degrees.com/1QWJwHxl). To
+use the resource key in the examples it can be supplied as an environment
+variable called "51DEGREES_RESOURCE_KEY". The legacy environment variable
+names "RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the
+aligned "51DEGREES_RESOURCE_KEY" name checked first.
 
 * In order to test cloud examples against a custom endpoint - you need to launch `OnPremise/Mixed/GettingStarted-API` example 
 and keep it running while launching other examples.  Depending on the IDE you use this can be either done conveniently from the IDE, or 

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
@@ -37,8 +37,8 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
 {
     /// <summary>
     /// Runs the Cloud examples against the real 51Degrees Cloud service
-    /// (cloud.51degrees.com by default). Requires the RESOURCE_KEY
-    /// environment variable to be set.
+    /// (cloud.51degrees.com by default). Requires the 51DEGREES_RESOURCE_KEY
+    /// (or legacy SUPER_RESOURCE_KEY) environment variable to be set.
     /// </summary>
     /// <remarks>
     /// Note that these tests do not generally ensure the correctness
@@ -53,8 +53,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
         [TestInitialize]
         public void Init()
         {
-            _resourceKey = Environment.GetEnvironmentVariable(
-                ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+            _resourceKey = ExampleUtils.GetResourceKeyFromEnv();
 
             Assert.IsFalse(
                 string.IsNullOrWhiteSpace(_resourceKey),

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
@@ -42,7 +42,8 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
     /// the expected IP Intelligence results for a known IP address.
     /// </summary>
     /// <remarks>
-    /// Requires the <c>RESOURCE_KEY</c> environment variable to be set. It also
+    /// Requires the <c>51DEGREES_RESOURCE_KEY</c> (or legacy
+    /// <c>SUPER_RESOURCE_KEY</c>) environment variable to be set. It also
     /// requires a trusted HTTPS development certificate, because the example
     /// binds its configured HTTPS endpoints on start-up (run
     /// <c>dotnet dev-certs https --trust</c> once if start-up fails with a
@@ -77,8 +78,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
         [TestInitialize]
         public void Init()
         {
-            var resourceKey = Environment.GetEnvironmentVariable(
-                ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR);
+            var resourceKey = ExampleUtils.GetResourceKeyFromEnv();
 
             Assert.IsFalse(
                 string.IsNullOrWhiteSpace(resourceKey),

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
@@ -49,7 +49,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise;
 /// These are integration tests: each example builds a real on-premise IP
 /// Intelligence engine against the enterprise data file. They therefore
 /// require the data file to be present (located automatically, or via the
-/// <c>IPINTELLIGENCEDATAFILE</c> environment variable) and are comparatively
+/// <c>51DEGREES_IPI_PATH</c> environment variable) and are comparatively
 /// slow. They go beyond pure smoke testing by asserting on the example output
 /// (expected section headers, echoed IPv4 evidence and known property names)
 /// rather than just that the example does not crash.
@@ -86,13 +86,8 @@ public class TestExamples
             licenseKey: "!!YOUR_LICENSE_KEY!!";
 
         // Set IP Intelligence Data file
-        DataFile = Environment.GetEnvironmentVariable(
-            Constants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
-        if (string.IsNullOrWhiteSpace(DataFile))
-        {
-            DataFile = ExampleUtils.FindFile(
-                Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
-        }
+        DataFile = ExampleUtils.FindDataFile(
+            Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
         File.WriteAllText($"{nameof(TestExamples)}_DataFileName.txt", DataFile);
 

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestGettingStartedOnPremise.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestGettingStartedOnPremise.cs
@@ -82,13 +82,8 @@ public class TestGettingStartedOnPremise
     [ClassInitialize]
     public static void ClassInit(TestContext context)
     {
-        _dataFile = Environment.GetEnvironmentVariable(
-            ExampleConstants.IP_INTELLIGENCE_DATA_FILE_ENV_VAR);
-        if (string.IsNullOrWhiteSpace(_dataFile))
-        {
-            _dataFile = ExampleUtils.FindFile(
-                ExampleConstants.ENTERPRISE_IPI_DATA_FILE_NAME);
-        }
+        _dataFile = ExampleUtils.FindDataFile(
+            ExampleConstants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
         if (string.IsNullOrWhiteSpace(_dataFile) || File.Exists(_dataFile) == false)
         {

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -40,6 +40,10 @@ dotnet dev-certs https
 
 $env:IPINTELLIGENCEDATAFILE = [IO.Path]::Combine($RepoPath, "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
 $env:RESOURCE_KEY = $Keys.TestResourceKey
+# Aligned environment variable names. These are checked first by the examples
+# and tests. The legacy names above are retained for backwards compatibility.
+${env:51DEGREES_IPI_PATH} = [IO.Path]::Combine($RepoPath, "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
+${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
 $env:IPINTELLIGENCELICENSEKEY_DOTNET = $Keys.DeviceDetection # TBD
 
 Write-Debug "env:IPINTELLIGENCEDATAFILE = <$($env:IPINTELLIGENCEDATAFILE)>"


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the examples with the convention shared across 51Degrees repositories.

- The resource key is read from `51DEGREES_RESOURCE_KEY` first. The legacy `RESOURCE_KEY` and `SUPER_RESOURCE_KEY` names are retained and checked second, so existing setups keep working.
- An explicit data file path can be supplied in `51DEGREES_IPI_PATH`, which is checked first. The legacy `IPINTELLIGENCEDATAFILE` name is retained and checked second. When neither is set the folder hierarchy is walked to find the expected file name, with the free Lite data file in the ip-intelligence-data location as the final fallback.
- Developer-facing messages now reference the aligned names and the README documents the resolution order.
- The CI setup script also sets the aligned names, with the legacy assignments retained.

## Notes

- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet run`.
