### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
+++ b/Examples/Cloud/Framework-Web/App_Data/51Degrees.json
@@ -4,7 +4,7 @@
       {
         "BuilderName": "CloudRequestEngine",
         // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-framework-web-app_data-51degrees.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/Cloud/Framework-Web/Default.aspx
+++ b/Examples/Cloud/Framework-Web/Default.aspx
@@ -212,7 +212,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx&amp;utm_term=client-side-evidence-and-apple-models">pricing page</a>.
             </div>
         <% } %>
     </div>   

--- a/Examples/Cloud/Framework-Web/Default.aspx.cs
+++ b/Examples/Cloud/Framework-Web/Default.aspx.cs
@@ -76,10 +76,10 @@ using System.Web.UI;
 /// the same as those that will be available in the configuration file. 
 /// 
 /// Note that you will need to create a 'resource key' using our 
-/// [configurator](https://configure.51degrees.com/1QWJwHxl) site in order to get this example to 
+/// [configurator](https://configure.51degrees.com/1QWJwHxl?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx.cs&amp;utm_term=header) site in order to get this example to 
 /// work. The previous link will pre-populate the key with the properties that are used in this
 /// example.
-/// See our [documentation](http://51degrees.com/documentation/4.4/_concepts__configurator.html) 
+/// See our [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx.cs&amp;utm_term=header) 
 /// for more detail on resource keys and the configurator site. Once created, the key will 
 /// need to be copied into the configuration file:
 /// 

--- a/Examples/Cloud/GetAllProperties-Console/Program.cs
+++ b/Examples/Cloud/GetAllProperties-Console/Program.cs
@@ -38,7 +38,7 @@ using System.Linq;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GetAllProperties-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-getallproperties-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 /// </summary>
 namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
 {
@@ -171,7 +171,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
             {
                 Console.WriteLine($"No resource key specified on the command line or in the " +
                     $"environment variable '{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. " +
-                    $"Obtain a resource key at https://configure.51degrees.com and supply it " +
+                    $"Obtain a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-getallproperties-console-program.cs&utm_term=resource-key-required and supply it " +
                     $"as the first argument or via that environment variable.");
             }
             else

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -48,7 +48,7 @@ using System.Text;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -69,7 +69,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
 
                 // In this example, we use the FiftyOnePipelineBuilder and configure it from a file.
                 // For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=run
 
                 // Create the pipeline using the service provider and the configured options.
                 using (var pipeline = new FiftyOnePipelineBuilder(loggerFactory, serviceProvider)
@@ -196,9 +196,9 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
                             $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees Cloud " +
                             $"service is accessed using a 'ResourceKey'. For more information " +
                             $"see " +
-                            $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                            $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=resource-key-required. " +
                             $"A resource key with the properties required by this example can be " +
-                            $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                            $"created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-program.cs&utm_term=resource-key-required. " +
                             $"Once complete, populate the config file or environment variable " +
                             $"mentioned at the start of this message with the key.");
                     }

--- a/Examples/Cloud/GettingStarted-Console/appsettings.json
+++ b/Examples/Cloud/GettingStarted-Console/appsettings.json
@@ -6,7 +6,7 @@
       {
         "BuilderName": "CloudRequestEngine",
         // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-console-appsettings.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/Cloud/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/GettingStarted-Web/Program.cs
@@ -41,7 +41,7 @@ using System.Threading;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GettingStarted-Web/Program.cs). 
 /// 
 /// Required setup:
-/// - Cloud resource key (get your free key at https://configure.51degrees.com)
+/// - Cloud resource key (get your free key at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-program.cs&amp;utm_term=header)
 /// - Configure the resource key in appsettings.json or via environment variables
 /// - Optionally, configure a custom endpoint URL for private Cloud services
 /// 
@@ -146,9 +146,9 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedWeb
                         $"'appsettings.json' or the environment variable " +
                         $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees Cloud " +
                         $"service is accessed using a 'ResourceKey'. For more information " +
-                        $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
+                        $"see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-program.cs&utm_term=resource-key-required. " +
                         $"A resource key with the properties required by this example can be " +
-                        $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                        $"created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-program.cs&utm_term=resource-key-required. " +
                         $"Once complete, populate the config file or environment variable " +
                         $"mentioned at the start of this message with the key.");
                 }

--- a/Examples/Cloud/GettingStarted-Web/Startup.cs
+++ b/Examples/Cloud/GettingStarted-Web/Startup.cs
@@ -72,7 +72,7 @@ using System.Threading.Tasks;
 /// ```
 /// 
 /// Results can also be accessed in client-side code by using the `fod` object. See the 
-/// [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-dotnet/class_fifty_one_1_1_pipeline_1_1_java_script_builder_1_1_flow_element_1_1_java_script_builder_element_builder.html)
+/// [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-dotnet/class_fifty_one_1_1_pipeline_1_1_java_script_builder_1_1_flow_element_1_1_java_script_builder_element_builder.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-startup.cs&amp;utm_term=header)
 /// for details on available settings such as changing the `fod` name.
 /// ```{js}
 /// window.onload = function () {

--- a/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
@@ -167,7 +167,7 @@
     {
         <div class="example-alert">
             WARNING: You are using the free 'Lite' data file. Find out about the Enterprise data file on our
-            <a href="https://51degrees.com/pricing">pricing page</a>.
+            <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-views-home-index.cshtml&amp;utm_term=response-headers">pricing page</a>.
         </div>
     }
 

--- a/Examples/Cloud/GettingStarted-Web/appsettings_51.json
+++ b/Examples/Cloud/GettingStarted-Web/appsettings_51.json
@@ -6,7 +6,7 @@
       {
         "BuilderName": "CloudRequestEngine",
         // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-gettingstarted-web-appsettings_51.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -50,7 +50,7 @@ using FiftyOne.Pipeline.Engines.Data;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Metadata-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-metadata-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -157,9 +157,9 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Metadata
                     $"'appsettings.json' or the environment variable " +
                     $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees Cloud service is " +
                     $"accessed using a 'ResourceKey'. For more information see " +
-                    $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                    $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-metadata-console-program.cs&utm_term=resource-key-required. " +
                     $"A resource key with the properties required by this example can be " +
-                    $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                    $"created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-metadata-console-program.cs&utm_term=resource-key-required. " +
                     $"Once complete, supply the resource key as a command line argument or via " +
                     $"the environment variable mentioned at the start of this message.");
             }

--- a/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
@@ -50,7 +50,7 @@ using FiftyOne.DeviceDetection.Cloud.FlowElements;
 /// 
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -71,7 +71,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
 
                 // In this example, we use the FiftyOnePipelineBuilder and configure it from a file.
                 // For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&utm_term=run
 
                 // Create the pipeline using the service provider and the configured options.
                 using (var pipeline = new FiftyOnePipelineBuilder(loggerFactory, serviceProvider)
@@ -263,9 +263,9 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
                             $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees Cloud " +
                             $"service is accessed using a 'ResourceKey'. For more information " +
                             $"see " +
-                            $"https://51degrees.com/documentation/_info__resource_keys.html. " +
+                            $"https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&utm_term=resource-key-required. " +
                             $"A resource key with the properties required by this example can be " +
-                            $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                            $"created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&utm_term=resource-key-required. " +
                             $"Once complete, populate the config file or environment variable " +
                             $"mentioned at the start of this message with the key.");
                     }

--- a/Examples/Cloud/Mixed/GettingStarted-Console/appsettings.json
+++ b/Examples/Cloud/Mixed/GettingStarted-Console/appsettings.json
@@ -6,7 +6,7 @@
       {
         "BuilderName": "CloudRequestEngine",
         // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-console-appsettings.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/Cloud/Mixed/GettingStarted-Web/Program.cs
+++ b/Examples/Cloud/Mixed/GettingStarted-Web/Program.cs
@@ -122,9 +122,9 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.Cloud.GettingStartedWeb
                         $"'appsettings.json' or the environment variable " +
                         $"'{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}'. The 51Degrees Cloud " +
                         $"service is accessed using a 'ResourceKey'. For more information " +
-                        $"see https://51degrees.com/documentation/_info__resource_keys.html. " +
+                        $"see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-web-program.cs&utm_term=resource-key-required. " +
                         $"A resource key with the properties required by this example can be " +
-                        $"created for free at https://configure.51degrees.com/1QWJwHxl. " +
+                        $"created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-web-program.cs&utm_term=resource-key-required. " +
                         $"Once complete, populate the config file or environment variable " +
                         $"mentioned at the start of this message with the key.");
                 }

--- a/Examples/Cloud/Mixed/GettingStarted-Web/appsettings.json
+++ b/Examples/Cloud/Mixed/GettingStarted-Web/appsettings.json
@@ -13,7 +13,7 @@
       {
         "BuilderName": "CloudRequestEngine",
         // Obtain a resource key with the properties required to run this 
-        // example for free: https://configure.51degrees.com/1QWJwHxl
+        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-cloud-mixed-gettingstarted-web-appsettings.json&utm_term=elements
         "BuildParameters": {
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
           "CloudRequestOrigin": "51Degrees.example.com"

--- a/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
@@ -284,14 +284,14 @@ namespace FiftyOne.IpIntelligence.Examples
                         $"data file is available from the ip-intelligence-data repository on " +
                         $"GitHub https://github.com/51Degrees/ip-intelligence-data. Find out " +
                         $"about the Enterprise data file, which includes automatic daily " +
-                        $"updates, on our pricing page: https://51degrees.com/pricing");
+                        $"updates, on our pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-fiftyone.ipintelligence.examples-exampleutils.cs&utm_term=data-file-age-warning");
                 }
                 if (info.Tier == "Lite")
                 {
                     logger.LogWarning($"This example is using the 'Lite' data file. This is " +
                         $"used for illustration, and has limited accuracy and capabilities. " +
                         $"Find out about the Enterprise data file on our pricing page: " +
-                        $"https://51degrees.com/pricing");
+                        $"https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-fiftyone.ipintelligence.examples-exampleutils.cs&utm_term=lite-data-file");
                 }
             }
         }

--- a/Examples/OnPremise/Compare-Console/Program.cs
+++ b/Examples/OnPremise/Compare-Console/Program.cs
@@ -92,7 +92,7 @@ using System.Threading.Tasks;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/Compare-Console/Program.cs). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-compare-console-program.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -311,7 +311,7 @@ public class Program
                 // LowMemory keeps the (multi-gigabyte) IP Intelligence data file on
                 // disk rather than loading it entirely into memory. See the
                 // documentation for more detail on this and other configuration options.
-                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
+                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-compare-console-program.cs&utm_term=run
                 .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                 // inhibit auto-update of the data file for this test
                 .SetAutoUpdate(false)
@@ -646,7 +646,7 @@ public class Program
             // specify another file as a command line parameter.
             //
             // For testing, contact us to obtain an enterprise data file:
-            // https://51degrees.com/contact-us
+            // https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-compare-console-program.cs&utm_term=main
                 Examples.ExampleUtils.FindDataFile(
                     Constants.ENTERPRISE_IPI_DATA_FILE_NAME),
 

--- a/Examples/OnPremise/Framework-Web/Default.aspx
+++ b/Examples/OnPremise/Framework-Web/Default.aspx
@@ -104,7 +104,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx&amp;utm_term=response-headers">pricing page</a>.
             </div>
         <% } %>
     </div>   

--- a/Examples/OnPremise/Framework-Web/Default.aspx.cs
+++ b/Examples/OnPremise/Framework-Web/Default.aspx.cs
@@ -36,7 +36,7 @@ using System.Web.UI;
 /// The source code for this example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/tree/master/Examples/OnPremise/Framework-Web).
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies: 
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -79,9 +79,9 @@ using System.Web.UI;
 /// Note that you will need to update the configuration with the complete path to a data file. 
 /// The free 'lite' file is included with this repository under the path `ip-intelligence-data`
 /// 
-/// Alternatively, you can obtain a [license key](http://51degrees.com/pricing) which can be used 
+/// Alternatively, you can obtain a [license key](https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx.cs&amp;utm_term=header) which can be used 
 /// to download a data file from our 
-/// [Distributor](https://51degrees.com/documentation/_info__distributor.html) service.
+/// [Distributor](https://51degrees.com/documentation/_info__distributor.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx.cs&amp;utm_term=header) service.
 /// 
 /// @include OnPremise/Framework-Web/App_Data/51Degrees.json
 /// 

--- a/Examples/OnPremise/GettingStarted-Console/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Console/Program.cs
@@ -53,7 +53,7 @@ using System.Text;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/GettingStarted-Console/Program.cs).
 ///
 /// This example requires an enterprise IP Intelligence data file (.ipi).
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-console-program.cs&amp;utm_term=header).
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)

--- a/Examples/OnPremise/GettingStarted-Web/Startup.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Startup.cs
@@ -43,7 +43,7 @@ using FiftyOne.IpIntelligence.Translation.FlowElements;
 /// The source code for this example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/tree/master/Examples/OnPremise/GettingStarted-Web). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-startup.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/)

--- a/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
@@ -51,7 +51,7 @@
         from the 
         <a href="https://github.com/51Degrees/ip-intelligence-data">ip-intelligence-data</a>
         repository on GitHub. Find out about the Enterprise data file, which includes automatic 
-        daily updates, on our <a href="https://51degrees.com/pricing">pricing page</a>.
+        daily updates, on our <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=ip-intelligence-web-integration-example">pricing page</a>.
     </div>
 }
 
@@ -182,7 +182,7 @@
     {
     <div class="example-alert">
         WARNING: You are using the free 'Lite' data file. Find out about the Enterprise data file on our
-        <a href="https://51degrees.com/pricing">pricing page</a>.
+        <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=response-headers">pricing page</a>.
     </div>
     }
     

--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -47,7 +47,7 @@ using System.Text;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/Metadata-Console/Program.cs). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-metadata-console-program.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -71,7 +71,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Metadata
                     // data file is paged from disk rather than loaded entirely into RAM.
                     // See the documentation for more detail on this and other
                     // configuration options.
-                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
+                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=run
                     .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                     // inhibit auto-update of the data file for this test
                     .SetAutoUpdate(false)
@@ -224,7 +224,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Metadata
                 // In this example, by default, the 51degrees IP Intelligence data file needs to be somewhere in the
                 // project space, or you may specify another file as a command line parameter.
                 //
-                // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
+                // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-metadata-console-program.cs&utm_term=main
                 Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
             File.WriteAllText("Metadata_DataFileName.txt", dataFile);

--- a/Examples/OnPremise/Metrics-Console/Program.cs
+++ b/Examples/OnPremise/Metrics-Console/Program.cs
@@ -68,7 +68,7 @@ using System.Threading.Tasks;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/Metrics-Console/Program.cs). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-metrics-console-program.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -683,7 +683,7 @@ public class Program
                 // LowMemory keeps the (multi-gigabyte) IP Intelligence data file on
                 // disk rather than loading it entirely into memory. See the
                 // documentation for more detail on this and other configuration options.
-                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
+                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-metrics-console-program.cs&utm_term=run
                 .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                 // inhibit auto-update of the data file for this test
                 .SetAutoUpdate(false)
@@ -1077,7 +1077,7 @@ public class Program
             // In this example, by default, the 51degrees IP Intelligence data file needs to be somewhere in the
             // project space, or you may specify another file as a command line parameter.
             //
-            // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
+            // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-metrics-console-program.cs&utm_term=main
             Examples.ExampleUtils.FindDataFile(
                 Constants.ENTERPRISE_IPI_DATA_FILE_NAME)
         };

--- a/Examples/OnPremise/OfflineProcessing-Console/Program.cs
+++ b/Examples/OnPremise/OfflineProcessing-Console/Program.cs
@@ -60,7 +60,7 @@ using YamlDotNet.Serialization;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/OfflineProcessing-Console/Program.cs). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-offlineprocessing-console-program.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -98,7 +98,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.OfflineProcessing
                 var logger = loggerFactory.CreateLogger<Program>();
                 // In this example, we use the IpiPipelineBuilder and configure it
                 // in code. For more information about builders in general see the documentation at
-                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+                // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
 
                 // Note that we wrap the creation of a pipeline in a using to control its life cycle
                 using (var pipeline = new IpiPipelineBuilder(loggerFactory)
@@ -107,8 +107,8 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.OfflineProcessing
                     // data file is paged from disk rather than loaded entirely into RAM.
                     // See the documentation for more detail on this and other
                     // configuration options.
-                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-                    // https://51degrees.com/documentation/_features__usage_sharing.html
+                    // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
+                    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run
                     .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                     // Inhibit sharing usage for this example.
                     // In general, off line processing usage should NOT be shared back to 51Degrees.
@@ -118,7 +118,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.OfflineProcessing
                     // in order to help us improve the detection, then
                     // this additional data will need to be collected and included as evidence
                     // to the Pipeline. See
-                    // https://51degrees.com/documentation/_features__usage_sharing.html#Low_Level_Usage_Sharing
+                    // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=run#Low_Level_Usage_Sharing
                     // for more details on this.
                     .SetShareUsage(false)
                     // Inhibit auto-update of the data file for this example
@@ -207,7 +207,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.OfflineProcessing
                 //
                 // Note that the Lite data file is only used for illustration, and has limited accuracy
                 // and capabilities. Find out about the Enterprise data file on our pricing page:
-                // https://51degrees.com/pricing
+                // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-offlineprocessing-console-program.cs&utm_term=main
                 Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
             File.WriteAllText("OfflineProcessing_DataFileName.txt", dataFile);

--- a/Examples/OnPremise/Performance-Console/Program.cs
+++ b/Examples/OnPremise/Performance-Console/Program.cs
@@ -61,7 +61,7 @@ using System.Threading.Tasks;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/Performance-Console/Program.cs).
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-performance-console-program.cs&amp;utm_term=header).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -376,7 +376,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Performance
                     //
                     // Note that the Lite data file is only used for illustration, and has limited accuracy
                     // and capabilities. Find out about the Enterprise data file on our pricing page:
-                    // https://51degrees.com/pricing
+                    // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-performance-console-program.cs&utm_term=main
                     Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
                 // Do the same for the yaml evidence file.
                 var evidenceFile = options.EvidenceFile != null ? options.EvidenceFile :

--- a/Examples/OnPremise/Suspicious-Console/Program.cs
+++ b/Examples/OnPremise/Suspicious-Console/Program.cs
@@ -46,7 +46,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Suspicious;
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/Suspicious-Console/Program.cs). 
 /// 
 /// This example requires an enterprise IP Intelligence data file (.ipi). 
-/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us).
+/// To obtain an enterprise data file for testing, please [contact us](https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-suspicious-console-program.cs&amp;utm_term=program).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -59,7 +59,7 @@ public class Program
         {
             // In this example, we use the IpiPipelineBuilder and configure it
             // in code. For more information about builders in general see the documentation at
-            // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+            // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-suspicious-console-program.cs&utm_term=run
 
             // Note that we wrap the creation of a pipeline in a using to control its life cycle
             using (var pipeline = new IpiPipelineBuilder()
@@ -68,8 +68,8 @@ public class Program
                 // data file is paged from disk rather than loaded entirely into RAM.
                 // See the documentation for more detail on this and other
                 // configuration options.
-                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
-                // https://51degrees.com/documentation/_features__usage_sharing.html
+                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-suspicious-console-program.cs&utm_term=run
+                // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-suspicious-console-program.cs&utm_term=run
                 .SetPerformanceProfile(PerformanceProfiles.LowMemory)
                 // inhibit sharing usage for this example, usually this should be set to "true"
                 .SetShareUsage(false)
@@ -169,7 +169,7 @@ public class Program
         // In this example, by default, the 51degrees IP Intelligence data file needs to be somewhere in the
         // project space, or you may specify another file as a command line parameter.
         //
-        // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us
+        // For testing, contact us to obtain an enterprise data file: https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-suspicious-console-program.cs&utm_term=main
         Examples.ExampleUtils.FindDataFile(Constants.ENTERPRISE_IPI_DATA_FILE_NAME);
 
         File.WriteAllText("Metadata_DataFileName.txt", dataFile);

--- a/Examples/OnPremise/UpdateDataFile-Console/Program.cs
+++ b/Examples/OnPremise/UpdateDataFile-Console/Program.cs
@@ -56,7 +56,7 @@ using System.Net.Http;
 /// For production use, you will eventually need to use a Distributor service and license key
 /// to keep your data file updated.
 /// 
-/// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us
+/// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-updatedatafile-console-program.cs&amp;utm_term=header
 /// 
 /// # Command Line Usage
 /// The data file path is provided via the first command line argument. Here's how it works:
@@ -284,7 +284,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                         // file to a temporary file (createTempDataCopy parameter == true).
                         //
                         // For automatic updates from the distributor service you will need to provide a license key.
-                        // A license key can be obtained with a subscription from https://51degrees.com/pricing
+                        // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=run
                         // For testing with a custom URL, no license key is required.
                         .UseOnPremise(dataFile, licenseKey ?? string.Empty, true)
                         // Enable update on startup, the auto update system
@@ -378,7 +378,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                 {
                     logger.LogError("In order to test this example you will need a 51Degrees " +
                                     "Enterprise license which can be obtained on a trial basis or purchased " +
-                                    "from our pricing page https://51degrees.com/pricing. You must supply the " +
+                                    "from our pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=license-key-required. You must supply the " +
                                     "license key " + KEY_SUBMISSION_PATHS);
                     throw new ArgumentException("No license key available", nameof(licenseKey));
                 }
@@ -496,7 +496,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                 {
                     Console.Error.WriteLine("In order to test this example you will need a 51Degrees " +
                                           "Enterprise license which can be obtained on a trial basis or purchased " +
-                                          "from our pricing page https://51degrees.com/pricing. You must supply the " +
+                                          "from our pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=license-key-or-update-url-required. You must supply the " +
                                           "license key " + KEY_SUBMISSION_PATHS + 
                                           ", or provide a custom data update URL using --data-update-url");
                     return 1;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=dotnet-open-source "Data rewards the curious") IP Intelligence Engine Examples
+# ![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet-examples&utm_content=readme.md&utm_term=top "Data rewards the curious") IP Intelligence Engine Examples
 
 This repository contains the examples for [[ip-intelligence-dotnet](https://github.com/51Degrees/ip-intelligence-dotnet/)].
 
@@ -69,7 +69,7 @@ dotnet add package FiftyOne.IpIntelligence --prerelease
 ## Cloud
 
 A resource key configured with the properties needed to run the cloud examples
-can be created for free [here](https://configure.51degrees.com/1QWJwHxl). To
+can be created for free [here](https://configure.51degrees.com/1QWJwHxl?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet-examples&utm_content=readme.md&utm_term=cloud). To
 use the resource key in the examples it can be supplied as an environment
 variable called "51DEGREES_RESOURCE_KEY". The legacy environment variable
 names "RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

66 links across 29 files, in-place URL replacements only, re-applied against the example restructure from the environment variable alignment merge. Functional endpoints, test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).