### PR TITLE
fix(utm): tag the contact-us links merged from #311

### DIFF
--- a/Examples/Cloud/Framework-Web/Default.aspx
+++ b/Examples/Cloud/Framework-Web/Default.aspx
@@ -227,8 +227,8 @@
         </div>
 
         <div class="c-eg-message">
-          <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
-          <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+          <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx&amp;utm_term=try-on-premise">Contact us</a> to discuss requirements.</p>
+          <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-framework-web-default.aspx&amp;utm_term=try-on-premise">Contact us</a>
         </div>
     </div>
 

--- a/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/GettingStarted-Web/Views/Home/Index.cshtml
@@ -182,8 +182,8 @@
     </div>
 
     <div class="c-eg-message">
-        <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
-        <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+        <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-views-home-index.cshtml&amp;utm_term=try-on-premise">Contact us</a> to discuss requirements.</p>
+        <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-web-views-home-index.cshtml&amp;utm_term=try-on-premise">Contact us</a>
     </div>
 </div>
 

--- a/Examples/Cloud/Mixed/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/Cloud/Mixed/GettingStarted-Web/Views/Home/Index.cshtml
@@ -296,8 +296,8 @@
     </div>
 
     <div class="c-eg-message">
-        <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
-        <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+        <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-mixed-gettingstarted-web-views-home-index.cshtml&amp;utm_term=try-on-premise">Contact us</a> to discuss requirements.</p>
+        <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-mixed-gettingstarted-web-views-home-index.cshtml&amp;utm_term=try-on-premise">Contact us</a>
     </div>
 </div>
 

--- a/Examples/OnPremise/Framework-Web/Default.aspx
+++ b/Examples/OnPremise/Framework-Web/Default.aspx
@@ -119,8 +119,8 @@
 
         <% if (engine.DataSourceTier == "Lite") { %>
             <div class="c-eg-message">
-              <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
-              <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+              <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx&amp;utm_term=on-premise-properties">Contact us</a> to explore the options.</p>
+              <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-framework-web-default.aspx&amp;utm_term=on-premise-properties">Contact us</a>
             </div>
         <% } %>
     </div>

--- a/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/OnPremise/GettingStarted-Web/Views/Home/Index.cshtml
@@ -197,8 +197,8 @@
     @if (Model.Engine.DataSourceTier == "Lite")
     {
         <div class="c-eg-message">
-            <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
-            <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+            <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=on-premise-properties">Contact us</a> to explore the options.</p>
+            <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-gettingstarted-web-views-home-index.cshtml&amp;utm_term=on-premise-properties">Contact us</a>
         </div>
     }
 </div>

--- a/Examples/OnPremise/Mixed/GettingStarted-Web/Views/Home/Index.cshtml
+++ b/Examples/OnPremise/Mixed/GettingStarted-Web/Views/Home/Index.cshtml
@@ -242,8 +242,8 @@
     @if (Model.IsLiteDataFile)
     {
         <div class="c-eg-message">
-            <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
-            <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+            <p class="c-eg-message__text">Need more on-premise properties and features? <a href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-mixed-gettingstarted-web-views-home-index.cshtml&amp;utm_term=on-premise-properties">Contact us</a> to explore the options.</p>
+            <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-mixed-gettingstarted-web-views-home-index.cshtml&amp;utm_term=on-premise-properties">Contact us</a>
         </div>
     }
 </div>


### PR DESCRIPTION
Follow-up to #311. The free-tier contact-us banner links merged just before the UTM tags were applied, so `main` currently carries untagged 51degrees.com navigational links and fails the utm-link-lint check. This adds the standard five UTM parameters (source/medium/campaign/content/term) to each contact-us link. No other changes.