### PR TITLE
Render a placeholder for properties missing from the resource key

### DIFF
--- a/Examples/FiftyOne.IpIntelligence.Examples/DataExtensions.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/DataExtensions.cs
@@ -42,7 +42,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// <returns></returns>
         public static string TryGetValue<TData>(this TData data, Func<TData, string> function)
             where TData : IElementData
-            => TryGetValue(data, function, ex => $"Unknown ({ex.Message})");
+            => TryGetValue(data, function, ex => ex.Message);
         
         /// <summary>
         /// Execute the specified function on the supplied <see cref="IElementData"/> instance.
@@ -55,7 +55,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// <returns></returns>
         public static IReadOnlyList<string> TryGetValue<TData>(this TData data, Func<TData, IReadOnlyList<string>> function)
             where TData : IElementData
-            => TryGetValue(data, function, ex => new[]{$"Unknown ({ex.Message})"});
+            => TryGetValue(data, function, ex => new[]{ex.Message});
         
         private static TResult TryGetValue<TData, TResult>(
             this TData data,
@@ -123,7 +123,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// </summary>
         private static string NoValue<T>(IAspectPropertyValue<T> apv)
         {
-            return $"Unknown ({(apv == null ? "property missing from the resource key or data file" : apv.NoValueMessage)})";
+            return $"No value ({(apv == null ? "property missing from the resource key or data file" : apv.NoValueMessage)})";
         }
         /// <inheritdoc cref="NoValue{T}(IAspectPropertyValue{T})"/>
         private static IReadOnlyList<string> NoValueList<T>(IAspectPropertyValue<T> apv)

--- a/Examples/FiftyOne.IpIntelligence.Examples/DataExtensions.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/DataExtensions.cs
@@ -82,37 +82,53 @@ namespace FiftyOne.IpIntelligence.Examples
         /// <returns></returns>
         public static string GetHumanReadable<T>(this IAspectPropertyValue<T> apv)
         {
-            return apv.HasValue ? apv.Value.ToString() : $"Unknown ({apv.NoValueMessage})";
+            return apv != null && apv.HasValue ? apv.Value.ToString() : NoValue(apv);
         }
         /// <inheritdoc cref="GetHumanReadable{T}(IAspectPropertyValue{T})"/>
         public static string GetHumanReadable<T>(this IAspectPropertyValue<IReadOnlyList<IWeightedValue<T>>> apv)
         {
-            if (!apv.HasValue)
-                return $"Unknown ({apv.NoValueMessage})";
-            
-            var values = apv.Value.Select(x => 
+            if (apv == null || !apv.HasValue)
+                return NoValue(apv);
+
+            var values = apv.Value.Select(x =>
                 Math.Abs(x.Weighting() - 1.0f) < 0.0001f ? x.Value.ToString() : $"({x.Value} @ {x.Weighting():F4})");
             return string.Join(", ", values);
         }
         /// <summary>
         /// Get a human-readable version of the specified <see cref="IAspectPropertyValue"/>.
-        /// If no value has be set, the result will be 'Unknown' + the 
+        /// If no value has be set, the result will be 'Unknown' + the
         /// <see cref="IAspectPropertyValue.NoValueMessage"/>.
         /// </summary>
         /// <param name="apv"></param>
         /// <returns></returns>
         public static IReadOnlyList<string> GetHumanReadableList<T>(this IAspectPropertyValue<IReadOnlyList<T>> apv)
         {
-            return apv.HasValue
+            return apv != null && apv.HasValue
                 ? apv.Value.Select(x => x.ToString()).ToList()
-                : (IReadOnlyList<string>)new[] { $"Unknown ({apv.NoValueMessage})" };
+                : NoValueList(apv);
         }
         /// <inheritdoc cref="GetHumanReadableList{T}(IAspectPropertyValue{IReadOnlyList{T}})"/>
         public static IReadOnlyList<string> GetHumanReadableList<T>(this IAspectPropertyValue<IReadOnlyList<IWeightedValue<T>>> apv)
         {
-            return apv.HasValue
+            return apv != null && apv.HasValue
                 ? apv.Value.Select(x => $"{x.Value} ({x.Weighting() * 100}%)").ToList()
-                : (IReadOnlyList<string>)new[] { $"Unknown ({apv.NoValueMessage})" };
+                : NoValueList(apv);
+        }
+
+        /// <summary>
+        /// Build the 'Unknown' message for a property that has no value. Handles the
+        /// case where the property is entirely absent from the response (a null
+        /// <see cref="IAspectPropertyValue{T}"/>), which happens when the resource key
+        /// or data file does not include the property.
+        /// </summary>
+        private static string NoValue<T>(IAspectPropertyValue<T> apv)
+        {
+            return $"Unknown ({(apv == null ? "property missing from the resource key or data file" : apv.NoValueMessage)})";
+        }
+        /// <inheritdoc cref="NoValue{T}(IAspectPropertyValue{T})"/>
+        private static IReadOnlyList<string> NoValueList<T>(IAspectPropertyValue<T> apv)
+        {
+            return new[] { NoValue(apv) };
         }
     }
 }


### PR DESCRIPTION
Relates to 51Degrees/device-detection-dotnet-examples#857

Same fix for the IP intelligence examples: the value helpers in `DataExtensions` dereferenced a null `IAspectPropertyValue`, causing an HTTP 500 when the resource key does not grant a displayed property. Null-guards the helpers so an absent property renders a placeholder instead of throwing, matching the Node, PHP, Python and Java examples.

Draft for review.