### PR TITLE
Align env var names with the main repo

### DIFF
--- a/Examples/Cloud/GetAllProperties-Console/Program.cs
+++ b/Examples/Cloud/GetAllProperties-Console/Program.cs
@@ -27,18 +27,18 @@ using System.Collections;
 using System.Linq;
 /// <summary>
 /// @example Cloud/GetAllProperties-Console/Program.cs
-/// 
+///
 /// This example shows how to retrieve all available IP Intelligence properties from the 51Degrees Cloud service.
-/// 
+///
 /// You will learn:
-/// 
+///
 /// 1. How to create a Pipeline that uses 51Degrees Cloud IP Intelligence
 /// 2. How to process an IP address and retrieve all available properties
 /// 3. How to enumerate through all the properties returned by the service
-/// 
+///
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GetAllProperties-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-getallproperties-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-getallproperties-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the _51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 /// </summary>
 namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
 {
@@ -94,7 +94,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
             }
 
             /// <summary>
-            /// Convert the given value into a human-readable string representation 
+            /// Convert the given value into a human-readable string representation
             /// </summary>
             /// <param name="propertyValue">
             /// Property value object to be converted
@@ -114,7 +114,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GetAllProperties
                 {
                     if (aspectPropertyValue.HasValue)
                     {
-                        // Get the type and value parameters from the 
+                        // Get the type and value parameters from the
                         // AspectPropertyValue instance.
                         basePropetyType = basePropetyType.GenericTypeArguments[0];
                         basePropertyValue = aspectPropertyValue.Value;

--- a/Examples/Cloud/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/GettingStarted-Console/Program.cs
@@ -39,16 +39,16 @@ using System.Text;
 /// @example Cloud/GettingStarted-Console/Program.cs
 ///
 /// This example shows how to use 51Degrees Cloud IP Intelligence to determine location and network details from IP addresses.
-/// 
+///
 /// You will learn:
-/// 
+///
 /// 1. How to create a Pipeline that uses 51Degrees Cloud IP Intelligence
 /// 2. How to pass input data (evidence) to the Pipeline
 /// 3. How to retrieve the results
-/// 
+///
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the _51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -162,7 +162,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
             }
 
             /// <summary>
-            /// This Run method is called by the example test to avoid the need to duplicate the 
+            /// This Run method is called by the example test to avoid the need to duplicate the
             /// service provider setup logic.
             /// </summary>
             /// <param name="options"></param>
@@ -178,13 +178,13 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
                     // Add an HttpClient instance. This is used for making requests to the
                     // Cloud service.
                     .AddSingleton<HttpClient>()
-                    // Add the builders that will be needed to create the engines specified in the 
+                    // Add the builders that will be needed to create the engines specified in the
                     // configuration file.
                     .AddSingleton<CloudRequestEngineBuilder>()
                     .AddSingleton<IpiCloudEngineBuilder>()
                     .BuildServiceProvider())
                 {
-                    // Get the resource key setting from the config file. 
+                    // Get the resource key setting from the config file.
                     var resourceKey = options.GetResourceKey();
 
                     // If we don't have a resource key then log an error.
@@ -229,13 +229,13 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.GettingStartedConsole
             // misnamed configuration keys.
             section.Bind(options, (o) => { o.ErrorOnUnknownConfiguration = true; });
 
-            // Get the resource key setting from the config file. 
+            // Get the resource key setting from the config file.
             var resourceKeyFromConfig = options.GetResourceKey();
             var configHasKey = string.IsNullOrWhiteSpace(resourceKeyFromConfig) == false &&
                     resourceKeyFromConfig.StartsWith("!!") == false;
 
             // If no resource key is specified in the config file then override it with the key
-            // from the environment variable / command line. 
+            // from the environment variable / command line.
             if (configHasKey == false)
             {
                 options.SetResourceKey(resourceKey);

--- a/Examples/Cloud/Metadata-Console/Program.cs
+++ b/Examples/Cloud/Metadata-Console/Program.cs
@@ -32,26 +32,26 @@ using FiftyOne.Pipeline.Engines.Data;
 /// <summary>
 /// @example Cloud/Metadata-Console/Program.cs
 ///
-/// The Cloud service exposes metadata that can provide additional information about the various 
+/// The Cloud service exposes metadata that can provide additional information about the various
 /// properties that might be returned.
 /// This example shows how to access this data and display the values available.
-/// 
+///
 /// A list of the properties will be displayed, along with some additional information about each
 /// property. Note that this is the list of properties used by the supplied resource key, rather
 /// than all properties that can be returned by the Cloud service.
-/// 
-/// In addition, the evidence keys that are accepted by the service are listed. These are the 
+///
+/// In addition, the evidence keys that are accepted by the service are listed. These are the
 /// keys that, when added to the evidence collection in flow data, could have some impact on the
 /// result that is returned.
-/// 
-/// Bear in mind that this is a list of ALL evidence keys accepted by all products offered by the 
+///
+/// Bear in mind that this is a list of ALL evidence keys accepted by all products offered by the
 /// cloud. If you are only using a single product (for example - device detection) then not all
 /// of these keys will be relevant.
-/// 
+///
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Metadata-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-metadata-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
-/// 
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-metadata-console-program.cs&amp;utm_term=header and supply it as the first command-line argument or via the _51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
 /// - [Microsoft.Extensions.Logging.Console](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Console/)
@@ -124,7 +124,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Metadata
                 foreach (var property in engine.Properties)
                 {
                     // Output some details about the property.
-                    // If we're outputting to console then we also add some formatting to make it 
+                    // If we're outputting to console then we also add some formatting to make it
                     // more readable.
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.BackgroundColor = ConsoleColor.DarkRed;
@@ -132,7 +132,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Metadata
                     Console.ResetColor();
                     var typeName = GetPrettyTypeName(
                         typeof(IAspectPropertyValue).IsAssignableFrom(property.Type)
-                            ? property.Type.GenericTypeArguments[0] 
+                            ? property.Type.GenericTypeArguments[0]
                             : property.Type);
                     output.WriteLine($"[Category: {property.Category}] ({typeName})");
                 }

--- a/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
+++ b/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs
@@ -41,16 +41,16 @@ using FiftyOne.DeviceDetection.Cloud.FlowElements;
 /// @example Cloud/Mixed/GettingStarted-Console/Program.cs
 ///
 /// This example demonstrates using both Device Detection and IP Intelligence from the 51Degrees Cloud service.
-/// 
+///
 /// You will learn:
-/// 
+///
 /// 1. How to create a Pipeline that uses both 51Degrees Cloud Device Detection and IP Intelligence
 /// 2. How to pass input data (User-Agent and IP address) to the Pipeline
 /// 3. How to retrieve device and IP intelligence results from a single pipeline
-/// 
+///
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/Cloud/Mixed/GettingStarted-Console/Program.cs).
 ///
-/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the 51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
+/// To run this example, create a Resource Key for free at https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-cloud-mixed-gettingstarted-console-program.cs&amp;utm_term=header and supply it via the appsettings.json file or the _51DEGREES_RESOURCE_KEY environment variable. By default the pipeline talks to cloud.51degrees.com; set 51D_CLOUD_ENDPOINT to point at a self-hosted Cloud service instead.
 ///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -136,7 +136,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
 
             private void AnalyseEvidence(
                 Dictionary<string, object> evidence,
-                IPipeline pipeline, 
+                IPipeline pipeline,
                 TextWriter output)
             {
                 // FlowData is used to convey information through the pipeline
@@ -160,19 +160,19 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
                     data.Process();
 
                     message = new StringBuilder();
-                    
+
                     // Get Device Detection results
                     message.AppendLine("\nDevice Detection Results:");
                     message.AppendLine("-" + new string('-', 24));
                     var device = data.Get<IDeviceData>();
                     OutputDeviceData(device, message);
-                    
+
                     // Get IP Intelligence results
                     message.AppendLine("\nIP Intelligence Results:");
                     message.AppendLine("-" + new string('-', 23));
                     var ipData = data.Get<IIpIntelligenceData>();
                     OutputIpData(ipData, message);
-                    
+
                     output.WriteLine(message.ToString());
                 }
             }
@@ -228,7 +228,7 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
             }
 
             /// <summary>
-            /// This Run method is called by the example test to avoid the need to duplicate the 
+            /// This Run method is called by the example test to avoid the need to duplicate the
             /// service provider setup logic.
             /// </summary>
             /// <param name="options"></param>
@@ -244,14 +244,14 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
                     // Add an HttpClient instance. This is used for making requests to the
                     // Cloud service.
                     .AddSingleton<HttpClient>()
-                    // Add the builders that will be needed to create the engines specified in the 
+                    // Add the builders that will be needed to create the engines specified in the
                     // configuration file.
                     .AddSingleton<CloudRequestEngineBuilder>()
                     .AddSingleton<IpiCloudEngineBuilder>()
                     .AddSingleton<DeviceDetectionCloudEngineBuilder>()
                     .BuildServiceProvider())
                 {
-                    // Get the resource key setting from the config file. 
+                    // Get the resource key setting from the config file.
                     var resourceKey = options.GetResourceKey();
 
                     // If we don't have a resource key then log an error.
@@ -296,13 +296,13 @@ namespace FiftyOne.IpIntelligence.Examples.Cloud.Mixed.GettingStartedConsole
             // misnamed configuration keys.
             section.Bind(options, (o) => { o.ErrorOnUnknownConfiguration = true; });
 
-            // Get the resource key setting from the config file. 
+            // Get the resource key setting from the config file.
             var resourceKeyFromConfig = options.GetResourceKey();
             var configHasKey = string.IsNullOrWhiteSpace(resourceKeyFromConfig) == false &&
                     resourceKeyFromConfig.StartsWith("!!") == false;
 
             // If no resource key is specified in the config file then override it with the key
-            // from the environment variable / command line. 
+            // from the environment variable / command line.
             if (configHasKey == false)
             {
                 options.SetResourceKey(resourceKey);

--- a/Examples/FiftyOne.IpIntelligence.Examples/Constants.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/Constants.cs
@@ -42,7 +42,7 @@ namespace FiftyOne.IpIntelligence.Examples
         public const string GEOIP_COMPARISON_EVIDENCE_FILE_NAME = "geoip_comparison_evidence.csv";
 
         /// <summary>
-        /// Environment variable key for the license key file to use for the 
+        /// Environment variable key for the license key file to use for the
         /// tests.
         /// </summary>
         public const string LICENSE_KEY_ENV_VAR = "IPINTELLIGENCELICENSEKEY_DOTNET";
@@ -52,7 +52,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// IP Intelligence data file. This aligned name is checked first,
         /// before any legacy variable names.
         /// </summary>
-        public const string IP_INTELLIGENCE_DATA_FILE_ENV_VAR = "51DEGREES_IPI_PATH";
+        public const string IP_INTELLIGENCE_DATA_FILE_ENV_VAR = "_51DEGREES_IPI_PATH";
 
         /// <summary>
         /// Legacy environment variable key used to supply an explicit path to
@@ -68,7 +68,7 @@ namespace FiftyOne.IpIntelligence.Examples
         public const string EVIDENCE_FILE_ENV_VAR = "EVIDENCEFILE";
 
         /// <summary>
-        /// Environment variable key for the geo ip truth 
+        /// Environment variable key for the geo ip truth
         /// evidence file to use for the tests.
         /// </summary>
         public const string GEOIP_TRUTH_EVIDENCE_FILE_ENV_VAR = "GEOIPEVIDENCEFILE";

--- a/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
+++ b/Examples/FiftyOne.IpIntelligence.Examples/ExampleUtils.cs
@@ -37,7 +37,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// to use when running cloud examples. This aligned name is checked
         /// first, before any legacy variable names.
         /// </summary>
-        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
+        public const string CLOUD_RESOURCE_KEY_ENV_VAR = "_51DEGREES_RESOURCE_KEY";
 
         /// <summary>
         /// The legacy environment variable key used to get the resource key
@@ -156,9 +156,9 @@ namespace FiftyOne.IpIntelligence.Examples
         }
 
         /// <summary>
-        /// Uses a background task to search for the specified filename within the working 
+        /// Uses a background task to search for the specified filename within the working
         /// directory.
-        /// If the file cannot be found, the algorithm will move to the parent directory and 
+        /// If the file cannot be found, the algorithm will move to the parent directory and
         /// repeat the process.
         /// This continues until the file is found or a timeout is triggered.
         /// </summary>
@@ -309,7 +309,7 @@ namespace FiftyOne.IpIntelligence.Examples
         {
             try
             {
-                if (key == null) 
+                if (key == null)
                 {
                     return true;
                 }
@@ -375,7 +375,7 @@ namespace FiftyOne.IpIntelligence.Examples
 
         /// <summary>
         /// Get the resource key from the environment. The aligned
-        /// '51DEGREES_RESOURCE_KEY' variable is checked first, followed by
+        /// '_51DEGREES_RESOURCE_KEY' variable is checked first, followed by
         /// the legacy 'RESOURCE_KEY' and 'SUPER_RESOURCE_KEY' variables.
         /// </summary>
         /// <returns>
@@ -401,7 +401,7 @@ namespace FiftyOne.IpIntelligence.Examples
         /// <summary>
         /// Get the resource key from the environment and run the action with
         /// the value, or an empty string if no resource key is set. The
-        /// aligned '51DEGREES_RESOURCE_KEY' variable is checked first,
+        /// aligned '_51DEGREES_RESOURCE_KEY' variable is checked first,
         /// followed by the legacy 'RESOURCE_KEY' and 'SUPER_RESOURCE_KEY'
         /// variables.
         /// </summary>

--- a/Examples/OnPremise/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/GettingStarted-Web/Program.cs
@@ -44,7 +44,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedWeb
 
         /// <summary>
         /// Used by unit tests to run the example in an almost identical manner
-        /// to a developer using the example. Returns the task that the web 
+        /// to a developer using the example. Returns the task that the web
         /// server is running in so that the test can trigger the cancellation
         /// token and then wait for the server to shutdown before finishing.
         /// </summary>
@@ -79,12 +79,12 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedWeb
         /// <summary>
         /// Typically, something like this will not be necessary.
         /// The IP Intelligence API will accept an absolute or relative path for the data file.
-        /// However, if a relative path is specified, it will only look in the current working 
+        /// However, if a relative path is specified, it will only look in the current working
         /// directory.
-        /// In our examples, we have many different projects and we don't want to have a copy of 
+        /// In our examples, we have many different projects and we don't want to have a copy of
         /// the data file for every single one.
-        /// In order to handle this, we dynamically search the project directories for the data 
-        /// file location and then override the configured setting with the absolute path if 
+        /// In order to handle this, we dynamically search the project directories for the data
+        /// file location and then override the configured setting with the absolute path if
         /// necessary.
         /// In a real-world scenario, you can just put the data file in your working directory
         /// or use an absolute path in the configuration file.
@@ -114,7 +114,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedWeb
 
             // Use the command line argument if provided. Otherwise, an explicit data file
             // path supplied in an environment variable takes precedence over the value in
-            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // the configuration file. The aligned '_51DEGREES_IPI_PATH' variable is checked
             // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
             var dataFile = dataFileOverride;
             if (string.IsNullOrWhiteSpace(dataFile))

--- a/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-API/Program.cs
@@ -37,11 +37,11 @@ using System.Security.Cryptography;
 
 /// <summary>
 /// @example OnPremise/GettingStarted-API/Program.cs
-/// 
-/// 
-/// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/GettingStarted-API/Program.cs). 
-/// 
-/// 
+///
+///
+/// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/GettingStarted-API/Program.cs).
+///
+///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
 /// </summary>
@@ -56,30 +56,30 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
         #region Customization Properties
         // ReSharper disable MemberCanBePrivate.Global
         // Properties are made public to enable reusing in other repos.
-        
+
         /// <summary>
         /// Program args.
         /// Passed to <see cref="WebApplication.CreateBuilder()"/>.
         /// </summary>
         public string[] Args { get; init; } = Array.Empty<string>();
-        
+
         /// <summary>
         /// Intended to injecting additional evidence
         /// that might be present in more real environment
-        /// (e.g. API Version). 
+        /// (e.g. API Version).
         /// </summary>
         public Action<IDictionary<string, object>>? UnconditionalEvidenceInjector { get; init; }
-        
+
         /// <summary>
         /// Allows injecting additional element builders into
         /// <see cref="WebApplicationBuilder.Services"/>
         /// before building the <see cref="Pipeline"/>.
         /// </summary>
         public Action<IServiceCollection>? ServiceInjector { get; init; }
-        
+
         // ReSharper restore MemberCanBePrivate.Global
         #endregion
-        
+
         public static void Main(string[] args)
         {
             var app = new Program
@@ -162,14 +162,14 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
 
             app.Map("/json", ProcessEvidence).WithName(nameof(ProcessEvidence));
             app.Map("/{resource}.json", ProcessEvidence).WithName(nameof(ProcessEvidence) + "WithResource");
-            
+
             if (rawOptions.TryGetElementConfig(
                     nameof(IpiOnPremiseEngine),
                     out _))
             {
                 app.MapGet("/download-ipi-gz", GetDataFile).WithName(nameof(GetDataFile));
-            } 
-            
+            }
+
             // Force pipeline initialization before accepting first request.
             app.Services.GetService<IPipeline>();
 
@@ -324,11 +324,11 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
             return Results.Json(keys);
         }
 
-        private IResult ProcessEvidence(string? resource, HttpContext context, IPipeline pipeline) 
+        private IResult ProcessEvidence(string? resource, HttpContext context, IPipeline pipeline)
         {
             var aggregated = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             UnconditionalEvidenceInjector?.Invoke(aggregated);
-            
+
             foreach (var kvp in context.Request.Query)
             {
                 var effectiveValue = kvp.Value.LastOrDefault() ?? string.Empty;
@@ -383,12 +383,12 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
         /// <summary>
         /// Typically, something like this will not be necessary.
         /// The IP Intelligence API will accept an absolute or relative path for the data file.
-        /// However, if a relative path is specified, it will only look in the current working 
+        /// However, if a relative path is specified, it will only look in the current working
         /// directory.
-        /// In our examples, we have many different projects and we don't want to have a copy of 
+        /// In our examples, we have many different projects and we don't want to have a copy of
         /// the data file for every single one.
-        /// In order to handle this, we dynamically search the project directories for the data 
-        /// file location and then override the configured setting with the absolute path if 
+        /// In order to handle this, we dynamically search the project directories for the data
+        /// file location and then override the configured setting with the absolute path if
         /// necessary.
         /// In a real-world scenario, you can just put the data file in your working directory
         /// or use an absolute path in the configuration file.
@@ -424,14 +424,14 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
                     out var ipiEngineOptions) == false)
             {
                 return;
-            } 
+            }
             var ipiEngineIndex = options.Elements.IndexOf(ipiEngineOptions);
             var dataFileConfigKey = $"PipelineOptions:Elements:{ipiEngineIndex}" +
                                     $":BuildParameters:DataFile";
 
             // Use the command line argument if provided. Otherwise, an explicit data file
             // path supplied in an environment variable takes precedence over the value in
-            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // the configuration file. The aligned '_51DEGREES_IPI_PATH' variable is checked
             // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
             var dataFile = dataFileOverride;
             if (string.IsNullOrWhiteSpace(dataFile))
@@ -493,7 +493,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI
         {
             // Get the index of the device detection engine element in the config file so that
             // we can create an override key for it.
-            
+
             if (options.TryGetElementConfig(
                     nameof(DeviceDetectionHashEngine),
                     out var hashEngineOptions) == false)

--- a/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs
+++ b/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs
@@ -36,19 +36,19 @@ using Microsoft.Extensions.Hosting;
 
 /// <summary>
 /// @example OnPremise/Mixed/GettingStarted-Web/Program.cs
-/// 
-/// This example demonstrates using both Device Detection and IP Intelligence 
-/// engines in a single web application pipeline. The engines process evidence 
+///
+/// This example demonstrates using both Device Detection and IP Intelligence
+/// engines in a single web application pipeline. The engines process evidence
 /// in parallel for optimal performance.
-/// 
-/// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs). 
-/// 
+///
+/// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/main/Examples/OnPremise/Mixed/GettingStarted-Web/Program.cs).
+///
 /// Required data files:
 /// - Device Detection data file (.hash format)
 /// - IP Intelligence data file (.ipi format)
-/// 
+///
 /// The paths to the data files should be provided as command line parameters
-/// 
+///
 /// Required NuGet Dependencies:
 /// - [FiftyOne.DeviceDetection](https://www.nuget.org/packages/FiftyOne.DeviceDetection/)
 /// - [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence/)
@@ -66,7 +66,7 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedWeb
 
         /// <summary>
         /// Used by unit tests to run the example in an almost identical manner
-        /// to a developer using the example. Returns the task that the web 
+        /// to a developer using the example. Returns the task that the web
         /// server is running in so that the test can trigger the cancellation
         /// token and then wait for the server to shutdown before finishing.
         /// </summary>
@@ -102,12 +102,12 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedWeb
         /// <summary>
         /// Typically, something like this will not be necessary.
         /// The IP Intelligence API will accept an absolute or relative path for the data file.
-        /// However, if a relative path is specified, it will only look in the current working 
+        /// However, if a relative path is specified, it will only look in the current working
         /// directory.
-        /// In our examples, we have many different projects and we don't want to have a copy of 
+        /// In our examples, we have many different projects and we don't want to have a copy of
         /// the data file for every single one.
-        /// In order to handle this, we dynamically search the project directories for the data 
-        /// file location and then override the configured setting with the absolute path if 
+        /// In order to handle this, we dynamically search the project directories for the data
+        /// file location and then override the configured setting with the absolute path if
         /// necessary.
         /// In a real-world scenario, you can just put the data file in your working directory
         /// or use an absolute path in the configuration file.
@@ -147,7 +147,7 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedWeb
 
             // Use the command line argument if provided. Otherwise, an explicit data file
             // path supplied in an environment variable takes precedence over the value in
-            // the configuration file. The aligned '51DEGREES_IPI_PATH' variable is checked
+            // the configuration file. The aligned '_51DEGREES_IPI_PATH' variable is checked
             // first, followed by the legacy 'IPINTELLIGENCEDATAFILE' variable.
             var dataFile = dataFileOverride;
             if (string.IsNullOrWhiteSpace(dataFile))
@@ -173,7 +173,7 @@ namespace FiftyOne.IpIntelligence.Examples.Mixed.OnPremise.GettingStartedWeb
                     $"variable.");
             }
             // The data file location provided in the configuration may be using an absolute or
-            // relative path. If it is relative then search for a matching file using the 
+            // relative path. If it is relative then search for a matching file using the
             // ExampleUtils.FindFile function.
             if (Path.IsPathRooted(dataFile) == false)
             {

--- a/Examples/OnPremise/UpdateDataFile-Console/Program.cs
+++ b/Examples/OnPremise/UpdateDataFile-Console/Program.cs
@@ -34,60 +34,60 @@ using System.Net.Http;
 
 /// <summary>
 /// @example OnPremise/UpdateDataFile-Console/Program.cs
-/// 
+///
 /// This example illustrates various parameters that can be adjusted when using the on-premise
 /// IP Intelligence engine, and controls when a new data file is sought and when it is loaded by
 /// the IP Intelligence software.
-/// 
+///
 /// Three main aspects are demonstrated:
 /// - Update on Start-Up
 /// - Filesystem Watcher
 /// - Daily auto-update
-/// 
+///
 /// # Testing Requirements
 /// To test this example, you need to:
 /// 1. Host an IP Intelligence data file (.ipi) at a custom URL accessible to this application
 /// 2. Provide that custom URL using the --data-update-url parameter
 /// 3. No license key is required when using a custom URL
-/// 
+///
 /// For local testing, you can use the GettingStarted-API example which exposes a local URL
 /// for downloading the gzipped data file. See the Command Line Usage section below for examples.
-/// 
+///
 /// For production use, you will eventually need to use a Distributor service and license key
 /// to keep your data file updated.
-/// 
+///
 /// To obtain access to enterprise data files for hosting, please contact us at https://51degrees.com/contact-us?utm_source=code&amp;utm_medium=example&amp;utm_campaign=ip-intelligence-dotnet-examples&amp;utm_content=examples-onpremise-updatedatafile-console-program.cs&amp;utm_term=header
-/// 
+///
 /// # Command Line Usage
 /// The data file path is provided via the first command line argument. Here's how it works:
-/// 
-/// 1. First argument: Data file path (optional - checks the 51DEGREES_IPI_PATH and legacy
+///
+/// 1. First argument: Data file path (optional - checks the _51DEGREES_IPI_PATH and legacy
 ///    IPINTELLIGENCEDATAFILE environment variables, then defaults to Constants.ENTERPRISE_IPI_DATA_FILE_NAME)
 /// 2. Second argument: License key (optional when using --data-update-url)
 /// 3. Option: --data-update-url for custom URL
-/// 
+///
 /// So to run the example, you would use:
-/// 
+///
 /// ```
 /// # With data file path and custom URL (no license key needed)
 /// ./UpdateDataFile /path/to/datafile.ipi --data-update-url http://localhost:5225/download-ipi-gz
-/// 
-/// # With just custom URL (uses default data file name)  
+///
+/// # With just custom URL (uses default data file name)
 /// ./UpdateDataFile --data-update-url http://localhost:5225/download-ipi-gz
-/// 
+///
 /// # With license key (no custom URL)
 /// ./UpdateDataFile /path/to/datafile.ipi your-license-key
 /// ```
-/// 
+///
 /// # Update on Start-Up
 /// You can configure the pipeline builder to download an Enterprise data file on start-up.
-/// 
+///
 /// ## Pre-Requisites
 /// - a license key
 /// - a file location for the download
 ///      - this may be an existing file - which will be overwritten
 ///      - or if it does not exist must end in ".ipi" and must be in an existing directory
-///      
+///
 /// ## Configuration
 /// - the pipeline must be configured to use a temp file
 /// ``` {c#}
@@ -98,7 +98,7 @@ using System.Net.Http;
 /// ``` {c#}
 ///      .setDataUpdateOnStartup(true)
 /// ```
-/// 
+///
 /// # File System Watcher
 /// You can configure the pipeline builder to watch for changes to the currently loaded
 /// IP Intelligence data file, and to replace the file currently in use with the new one. This is
@@ -109,13 +109,13 @@ using System.Net.Http;
 /// ## Pre-Requisites
 /// - a license key
 /// - the file location of the existing file
-/// 
+///
 /// ## Configuration
 /// - the pipeline must be configured to use a temp file
 /// ``` {c#}
 ///    .UseOnPremise(dataFilename, true)
 /// ```
-/// 
+///
 /// ## Daily auto-update
 /// Enterprise data files are usually created four times a week. Each data file contains a date
 /// for when the next data file is expected. You can configure the pipeline so that it starts
@@ -126,7 +126,7 @@ using System.Net.Http;
 /// ## Pre-Requisites
 /// - a license key
 /// - the file location of the existing file
-/// 
+///
 /// ## Configuration
 /// - the pipeline must be configured with a license key and the 'use temp file' flag must be set.
 /// ``` {c#}
@@ -143,7 +143,7 @@ using System.Net.Http;
 /// ``` {c#}
 ///    .SetUpdateRandomisationMax(10*60)
 /// ```
-/// 
+///
 /// # Location
 /// This example is available in full on [GitHub](https://github.com/51Degrees/ip-intelligence-dotnet-examples/blob/master/Examples/OnPremise/UpdateDataFile-Console/Program.cs).
 /// </summary>
@@ -182,7 +182,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
             /// <param name="engineBuilder">
             /// A builder used to create an on-premise IP Intelligence engine.
             /// Generally, we wouldn't need this in addition to the pipeline builder above.
-            /// In this example, we use it to check information about the data file before 
+            /// In this example, we use it to check information about the data file before
             /// creating the full pipeline.
             /// </param>
             /// <param name="completionListener">
@@ -190,7 +190,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
             /// completed.
             /// </param>
             /// <param name="logger"></param>
-            public Example(IpiPipelineBuilder pipelineBuilder, 
+            public Example(IpiPipelineBuilder pipelineBuilder,
                 IpiOnPremiseEngineBuilder engineBuilder,
                 CompletionListener completionListener,
                 ILogger<Example> logger)
@@ -206,8 +206,8 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
             /// </summary>
             /// <param name="dataFile">
             /// Path to a data file to use in this example. May be absolute or relative.
-            /// If relative, the example will search for a matching file in the project 
-            /// directories. 
+            /// If relative, the example will search for a matching file in the project
+            /// directories.
             /// </param>
             /// <param name="licenseKey">
             /// The license key to use when requesting a data file update.
@@ -301,16 +301,16 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                         // between checks to see if the file has changed to 1 second.
                         // By default, this is 30 mins.
                         .SetUpdatePollingInterval(1);
-                    
+
                     if (dataUpdateUrl is not null)
                     {
                         builder.SetDataUpdateUrl(dataUpdateUrl);
                         builder.SetDataUpdateVerifyMd5(false);
                     }
-                    
+
                     // Build the pipeline.
                     using var pipeline = builder.Build();
-                    
+
                     // thread blocks till update checking is complete - or if there is an
                     // exception we don't get this far
                     Logger.LogInformation("Update on start-up complete - status - " +
@@ -421,7 +421,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                 return dataFile;
             }
         }
-        
+
         private const string KEY_SUBMISSION_ALT_PATH = $"as an environment variable named '{Constants.LICENSE_KEY_ENV_VAR}'";
         private const string KEY_SUBMISSION_PATHS = "as the second command line argument to this program, or " + KEY_SUBMISSION_ALT_PATH;
 
@@ -467,13 +467,13 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
             };
             dataUpdateUrl.Validators.Add(url =>
             {
-                if(url.Tokens.FirstOrDefault()?.Value is { } urlString 
+                if(url.Tokens.FirstOrDefault()?.Value is { } urlString
                    && !Uri.IsWellFormedUriString(urlString, UriKind.Absolute))
                 {
                     url.AddError($"Value provided for '{dataUpdateUrl.Name}' is not a valid absolute URL.");
                 }
             });
-            
+
             var rootCommand = new RootCommand("Data file update sample.");
 
             rootCommand.Arguments.Add(dataFile);
@@ -485,30 +485,30 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                 string dataFilePath = parseResult.GetValue(dataFile)!;
                 string? licenseKeyValue = parseResult.GetValue(licenseKey);
                 string? dataUpdateUrlValue = parseResult.GetValue(dataUpdateUrl);
-                
+
                 // Validate license key only if no custom data update URL is provided
                 if (string.IsNullOrWhiteSpace(licenseKeyValue))
                 {
                     licenseKeyValue = Environment.GetEnvironmentVariable(Constants.LICENSE_KEY_ENV_VAR);
                 }
-                
+
                 if (string.IsNullOrWhiteSpace(licenseKeyValue) && string.IsNullOrWhiteSpace(dataUpdateUrlValue))
                 {
                     Console.Error.WriteLine("In order to test this example you will need a 51Degrees " +
                                           "Enterprise license which can be obtained on a trial basis or purchased " +
                                           "from our pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=ip-intelligence-dotnet-examples&utm_content=examples-onpremise-updatedatafile-console-program.cs&utm_term=license-key-or-update-url-required. You must supply the " +
-                                          "license key " + KEY_SUBMISSION_PATHS + 
+                                          "license key " + KEY_SUBMISSION_PATHS +
                                           ", or provide a custom data update URL using --data-update-url");
                     return 1;
                 }
-                
+
                 // Work out where the data file is if we don't have an absolute path.
                 if (!string.IsNullOrWhiteSpace(dataFilePath) && !Path.IsPathRooted(dataFilePath))
                 {
                     var fullPath = Examples.ExampleUtils.FindFile(dataFilePath);
                     dataFilePath = fullPath ?? Path.Combine(Directory.GetCurrentDirectory(), dataFilePath);
                 }
-                
+
                 Initialize(
                     dataFilePath,
                     licenseKeyValue!,
@@ -531,7 +531,7 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.UpdateDataFile
                     .AddConsole()
                     // Only display messages @ warning or above.
                     // Or info and above if the come from this example.
-                    // This filters out some messages from the Pipeline that would otherwise 
+                    // This filters out some messages from the Pipeline that would otherwise
                     // make this example harder to follow.
                     .AddFilter((c, l) =>
                         (l >= LogLevel.Warning

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Both data files should be obtained from the respective repositories:
 The on-premise examples need an IP Intelligence data file. The examples locate
 the file in the following order:
 
-1. The "51DEGREES_IPI_PATH" environment variable, which can be set to an
+1. The "_51DEGREES_IPI_PATH" environment variable, which can be set to an
    explicit path to the data file. The legacy "IPINTELLIGENCEDATAFILE"
    environment variable is also still supported, and is checked after
-   "51DEGREES_IPI_PATH".
+   "_51DEGREES_IPI_PATH".
 2. A search of the folder hierarchy, walking up from the working directory,
    for the expected data file name.
 3. The free 'Lite' data file in its expected location, which is the
@@ -41,7 +41,7 @@ the file in the following order:
 
 ## 📦 NuGet Package
 
-Examples currently depend on a pre-release version of the [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence) package.  
+Examples currently depend on a pre-release version of the [FiftyOne.IpIntelligence](https://www.nuget.org/packages/FiftyOne.IpIntelligence) package.
 
 ❗Make sure to enable pre-release packages when installing it:
 * Using the .NET CLI:
@@ -71,13 +71,13 @@ dotnet add package FiftyOne.IpIntelligence --prerelease
 A resource key configured with the properties needed to run the cloud examples
 can be created for free [here](https://configure.51degrees.com/1QWJwHxl?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-dotnet-examples&utm_content=readme.md&utm_term=cloud). To
 use the resource key in the examples it can be supplied as an environment
-variable called "51DEGREES_RESOURCE_KEY". The legacy environment variable
+variable called "_51DEGREES_RESOURCE_KEY". The legacy environment variable
 names "RESOURCE_KEY" and "SUPER_RESOURCE_KEY" are still supported, with the
-aligned "51DEGREES_RESOURCE_KEY" name checked first.
+aligned "_51DEGREES_RESOURCE_KEY" name checked first.
 
-* In order to test cloud examples against a custom endpoint - you need to launch `OnPremise/Mixed/GettingStarted-API` example 
-and keep it running while launching other examples.  Depending on the IDE you use this can be either done conveniently from the IDE, or 
-just using `dotnet run` in the `OnPremise/Mixed/GettingStarted-API` directory from the command line.  
+* In order to test cloud examples against a custom endpoint - you need to launch `OnPremise/Mixed/GettingStarted-API` example
+and keep it running while launching other examples.  Depending on the IDE you use this can be either done conveniently from the IDE, or
+just using `dotnet run` in the `OnPremise/Mixed/GettingStarted-API` directory from the command line.
 
 | Example                          | Target               | Use case                                                                  |
 | -------------------------------- | -------------------- | ------------------------------------------------------------------------- |

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
@@ -37,7 +37,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
 {
     /// <summary>
     /// Runs the Cloud examples against the real 51Degrees Cloud service
-    /// (cloud.51degrees.com by default). Requires the 51DEGREES_RESOURCE_KEY
+    /// (cloud.51degrees.com by default). Requires the _51DEGREES_RESOURCE_KEY
     /// (or legacy SUPER_RESOURCE_KEY) environment variable to be set.
     /// </summary>
     /// <remarks>

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
@@ -42,7 +42,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
     /// the expected IP Intelligence results for a known IP address.
     /// </summary>
     /// <remarks>
-    /// Requires the <c>51DEGREES_RESOURCE_KEY</c> (or legacy
+    /// Requires the <c>_51DEGREES_RESOURCE_KEY</c> (or legacy
     /// <c>SUPER_RESOURCE_KEY</c>) environment variable to be set. It also
     /// requires a trusted HTTPS development certificate, because the example
     /// binds its configured HTTPS endpoints on start-up (run

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
@@ -49,7 +49,7 @@ namespace FiftyOne.IpIntelligence.Example.Tests.OnPremise;
 /// These are integration tests: each example builds a real on-premise IP
 /// Intelligence engine against the enterprise data file. They therefore
 /// require the data file to be present (located automatically, or via the
-/// <c>51DEGREES_IPI_PATH</c> environment variable) and are comparatively
+/// <c>_51DEGREES_IPI_PATH</c> environment variable) and are comparatively
 /// slow. They go beyond pure smoke testing by asserting on the example output
 /// (expected section headers, echoed IPv4 evidence and known property names)
 /// rather than just that the example does not crash.

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -38,12 +38,8 @@ if ($IsLinux) {
 
 dotnet dev-certs https
 
-$env:IPINTELLIGENCEDATAFILE = [IO.Path]::Combine($RepoPath, "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
-$env:RESOURCE_KEY = $Keys.TestResourceKey
-# Aligned environment variable names. These are checked first by the examples
-# and tests. The legacy names above are retained for backwards compatibility.
-${env:51DEGREES_IPI_PATH} = [IO.Path]::Combine($RepoPath, "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
-${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
+${env:_51DEGREES_IPI_PATH} = [IO.Path]::Combine($RepoPath, "ip-intelligence-data", "51Degrees-EnterpriseIpiV41.ipi")
+${env:_51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
 $env:IPINTELLIGENCELICENSEKEY_DOTNET = $Keys.DeviceDetection # TBD
 
 Write-Debug "env:IPINTELLIGENCEDATAFILE = <$($env:IPINTELLIGENCEDATAFILE)>"


### PR DESCRIPTION
`ip-intellignce-dotnet` switched to underscore-prefixed 51DEGREES variables to avoid issues with software that expects them to be valid identifier.