### PR TITLE
FEAT: Improve Examples Test Coverage 

### DIFF
--- a/Examples/OnPremise/Metadata-Console/Program.cs
+++ b/Examples/OnPremise/Metadata-Console/Program.cs
@@ -27,6 +27,7 @@ using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.FiftyOne.Data;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -116,16 +117,43 @@ namespace FiftyOne.IpIntelligence.Examples.OnPremise.Metadata
 
             }
 
+            // The IP Intelligence data file can contain tens of millions of
+            // profiles. Enumerating every one can take a long time.
+            // To keep this example responsive, stop after this many profiles and
+            // report the counts gathered so far.
+            private const long MaxProfilesToCount = 50000;
+
             private void OutputProfileDetails(IpiOnPremiseEngine ddEngine, TextWriter output)
             {
-                // Group the profiles by component and then output the number of profiles 
-                // for each component.
-                var groups = ddEngine.Profiles.GroupBy(p => p.Component.Name);
+                // Count the profiles per component in a single streaming pass,
+                // stopping once the limit is reached.
+                var countsByComponent = new Dictionary<string, long>();
+                long total = 0;
+                foreach (var profile in ddEngine.Profiles)
+                {
+                    var componentName = profile.Component.Name;
+                    countsByComponent.TryGetValue(componentName, out var current);
+                    countsByComponent[componentName] = current + 1;
+                    if (++total >= MaxProfilesToCount)
+                    {
+                        break;
+                    }
+                }
+
+                var limitReached = total >= MaxProfilesToCount;
                 output.WriteLine();
                 output.WriteLine($"Profile counts:");
-                foreach (var group in groups)
+                foreach (var entry in countsByComponent)
                 {
-                    output.WriteLine($"{group.Key} Profiles: {group.Count()}");
+                    // When the limit was hit these are lower bounds, so flag them.
+                    output.WriteLine(
+                        $"{entry.Key} Profiles: {entry.Value}{(limitReached ? "+" : "")}");
+                }
+                if (limitReached)
+                {
+                    output.WriteLine(
+                        $"(stopped after {MaxProfilesToCount} profiles to stay " +
+                        "responsive.");
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -102,3 +102,42 @@ The **Mixed examples** demonstrate how to combine Device Detection and IP Intell
   - Client-side evidence collection for enhanced device detection
   - Client hints support for improved browser detection
   - All device detection and IP intelligence properties displayed
+
+## Testing
+
+Automated tests live in the `Tests/` folder and run as part of CI:
+
+| Test project                                            | Covers                                              |
+| ------------------------------------------------------- | --------------------------------------------------- |
+| `FiftyOne.IpIntelligence.Example.Tests.Cloud`           | The Cloud console examples and Cloud web examples   |
+| `FiftyOne.IpIntelligence.Example.Tests.OnPremise`       | The on-premise console examples                     |
+| `FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI.Tests` | The on-premise `Mixed/GettingStarted-API` example |
+
+Most runnable examples have an associated test. The exceptions, and why:
+
+- **`Cloud/Framework-Web` and `OnPremise/Framework-Web`** are legacy **.NET
+  Framework 4.6.2** ASP.NET (MVC / full-framework) applications. They are excluded
+  from the cross-platform `net10.0` solution filter
+  (`FiftyOne.IpIntelligence.Examples.Core.slnf`) and from the CI test run (which
+  targets .NET on Linux, macOS and Windows), cannot be hosted in-process by the
+  `net10.0` test harness, and are therefore verified by compilation only.
+- **`OnPremise/GettingStarted-Web` and `OnPremise/Mixed/GettingStarted-Web`** are
+  exercised manually rather than by an automated test. Unlike the Cloud web
+  examples (which are tested in-process), these resolve their on-premise data file
+  through a relative-path configuration override; hosting them in-process from the
+  test project corrupts the pipeline element configuration. They run correctly
+  when launched normally (`dotnet run`), which is how they should be verified
+  until the in-process hosting issue is addressed.
+
+### Test prerequisites
+
+The example tests are integration tests and need the same inputs the examples do:
+
+- **Cloud example tests** require a resource key in the `51DEGREES_RESOURCE_KEY`
+  environment variable (see the [Cloud](#cloud) section). Without it these tests
+  fail with a message explaining how to obtain one.
+- **On-premise example tests** require the enterprise IP Intelligence data file
+  (located automatically, or via `51DEGREES_IPI_PATH`) and the **Mixed** examples
+  additionally require a device detection data file. When a required data file is
+  absent, those tests report **inconclusive** rather than failing, so the gap is
+  visible without being masked as a regression.

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ The **Mixed examples** demonstrate how to combine Device Detection and IP Intell
 
 Automated tests live in the `Tests/` folder and run as part of CI:
 
-| Test project                                            | Covers                                              |
-| ------------------------------------------------------- | --------------------------------------------------- |
-| `FiftyOne.IpIntelligence.Example.Tests.Cloud`           | The Cloud console examples and Cloud web examples   |
-| `FiftyOne.IpIntelligence.Example.Tests.OnPremise`       | The on-premise console examples                     |
-| `FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI.Tests` | The on-premise `Mixed/GettingStarted-API` example |
+| Test project                                                         | Covers                                              |
+| ---------------------------------------------------------------------| --------------------------------------------------- |
+| `FiftyOne.IpIntelligence.Example.Tests.Cloud`                        | The Cloud console examples and Cloud web examples   |
+| `FiftyOne.IpIntelligence.Example.Tests.OnPremise`                    | The on-premise console examples                     |
+| `FiftyOne.IpIntelligence.Examples.OnPremise.GettingStartedAPI.Tests` | The on-premise `Mixed/GettingStarted-API` example   |
 
 Most runnable examples have an associated test. The exceptions, and why:
 

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/FiftyOne.IpIntelligence.Example.Tests.Cloud.csproj
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/FiftyOne.IpIntelligence.Example.Tests.Cloud.csproj
@@ -32,9 +32,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Examples\Cloud\GettingStarted-Console\GettingStarted-Console.csproj" />
-    <!-- Referenced so the web example can be hosted in-process by TestCloudWebExample.
-         Brings in the ASP.NET Core framework transitively. -->
     <ProjectReference Include="..\..\Examples\Cloud\GettingStarted-Web\GettingStarted-Web.csproj" />
+    <ProjectReference Include="..\..\Examples\Cloud\Mixed\GettingStarted-Web\GettingStarted-Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudExamples.cs
@@ -31,6 +31,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 [assembly: Parallelize]
 namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
@@ -71,6 +72,10 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
             Path.Combine(RepoRootPath, "Examples", "Cloud", "GettingStarted-Console");
         private static readonly string MixedCloudExamplePath =
             Path.Combine(RepoRootPath, "Examples", "Cloud", "Mixed", "GettingStarted-Console");
+        private static readonly string GetAllPropertiesExamplePath =
+            Path.Combine(RepoRootPath, "Examples", "Cloud", "GetAllProperties-Console");
+        private static readonly string MetadataExamplePath =
+            Path.Combine(RepoRootPath, "Examples", "Cloud", "Metadata-Console");
 
         public static IEnumerable<object[]> CloudExamplesToTest =>
         [
@@ -127,6 +132,91 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
             string[] ipRanges,
             string rangeDescriptor)
         {
+            var (exitCode, result, errorOutput) = RunCloudExampleProcess(examplePath);
+
+            Assert.AreEqual(0, exitCode,
+                $"Cloud example should exit successfully. Error output: {errorOutput}");
+
+            Assert.Contains("Input values:", result,
+                "Output should contain input values section");
+            Assert.Contains("Results:", result,
+                "Output should contain results section");
+
+            Assert.IsTrue(networkNames.Any(x => result.Contains(x)),
+                $"Output should contain {networkNames[0]} as registered name");
+            Assert.IsTrue(countryNames.Any(x => result.Contains(x)),
+                $"Output should contain {countryNames[0]} as country or code");
+            Assert.IsTrue(ipRanges.Any(x => result.Contains(x)),
+                $"Output should contain IP range values {rangeDescriptor}");
+
+            Assert.IsTrue(Regex.IsMatch(result, @"\d+\.\d+\.\d+\.\d+"),
+                "Output should contain IP address values in dotted decimal format");
+
+            Assert.IsTrue(Regex.IsMatch(result, @"[\d\-]\d+\.\d+"),
+                "Output should contain numeric values (coordinates, ranges, etc.)");
+
+            Assert.DoesNotContain("Exception", result,
+                "Output should not contain exceptions");
+            Assert.DoesNotContain("Error", result,
+                "Output should not contain errors");
+        }
+
+        /// <summary>
+        /// Runs the GetAllProperties Cloud example and verifies it lists the
+        /// property values returned for the analysed IP address.
+        /// </summary>
+        [TestMethod]
+        public void Example_Cloud_GetAllProperties()
+        {
+            var (exitCode, result, errorOutput) =
+                RunCloudExampleProcess(GetAllPropertiesExamplePath);
+
+            Assert.AreEqual(0, exitCode,
+                $"GetAllProperties example should exit successfully. " +
+                $"Error output: {errorOutput}");
+
+            Assert.Contains("What property values are associated with", result,
+                "Output should introduce the property values for an IP address.");
+            Assert.IsTrue(
+                Regex.IsMatch(result, @".+ = .+"),
+                "Output should list properties as 'name = value' pairs.");
+            Assert.DoesNotContain("Unhandled exception", result,
+                "Output should not contain an unhandled exception.");
+        }
+
+        /// <summary>
+        /// Runs the Metadata Cloud example and verifies it prints the engine
+        /// metadata sections (accepted evidence keys and the property listing).
+        /// </summary>
+        [TestMethod]
+        public void Example_Cloud_Metadata()
+        {
+            var (exitCode, result, errorOutput) =
+                RunCloudExampleProcess(MetadataExamplePath);
+
+            Assert.AreEqual(0, exitCode,
+                $"Metadata example should exit successfully. " +
+                $"Error output: {errorOutput}");
+
+            Assert.Contains("Accepted evidence keys:", result,
+                "Metadata output should list the accepted evidence keys.");
+            Assert.Contains("Property -", result,
+                "Metadata output should list the available properties.");
+            Assert.DoesNotContain("Unhandled exception", result,
+                "Output should not contain an unhandled exception.");
+        }
+
+        /// <summary>
+        /// Runs a Cloud console example exactly as a user would (via
+        /// <c>dotnet run</c> in the example's own directory), passing the
+        /// resource key and optional custom endpoint through the same
+        /// environment variables the example reads. Standard input is closed so
+        /// examples that pause for a key press (guarded by
+        /// <see cref="Console.IsInputRedirected"/>) do not block the test.
+        /// </summary>
+        private (int ExitCode, string Output, string Error) RunCloudExampleProcess(
+            string examplePath)
+        {
             var startInfo = new ProcessStartInfo
             {
                 FileName = "dotnet",
@@ -134,11 +224,10 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
+                RedirectStandardInput = true,
                 WorkingDirectory = examplePath,
                 CreateNoWindow = true,
             };
-            // Pass the resource key (and optional custom endpoint) through to
-            // the example process; it picks them up via the same env vars.
             startInfo.Environment[ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR] = _resourceKey;
             var endPoint = Environment.GetEnvironmentVariable(
                 ExampleUtils.CLOUD_END_POINT_ENV_VAR);
@@ -147,68 +236,46 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
                 startInfo.Environment[ExampleUtils.CLOUD_END_POINT_ENV_VAR] = endPoint;
             }
 
-            using (var process = new Process { StartInfo = startInfo })
+            using var process = new Process { StartInfo = startInfo };
+            var output = new StringBuilder();
+            var error = new StringBuilder();
+
+            process.OutputDataReceived += (sender, e) =>
             {
-                var output = new StringBuilder();
-                var error = new StringBuilder();
+                if (e.Data != null)
+                    output.AppendLine(e.Data);
+            };
 
-                process.OutputDataReceived += (sender, e) =>
-                {
-                    if (e.Data != null)
-                        output.AppendLine(e.Data);
-                };
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (e.Data != null)
+                    error.AppendLine(e.Data);
+            };
 
-                process.ErrorDataReceived += (sender, e) =>
-                {
-                    if (e.Data != null)
-                        error.AppendLine(e.Data);
-                };
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            // Signal end-of-input so the example never waits for a key press.
+            process.StandardInput.Close();
 
-                process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
+            Assert.IsTrue(process.WaitForExit(60000),
+                "Cloud example should complete within 60 seconds");
+            // Block until the async output handlers have flushed everything.
+            process.WaitForExit();
 
-                Assert.IsTrue(process.WaitForExit(60000),
-                    "Cloud example should complete within 60 seconds");
+            var result = output.ToString();
+            var errorOutput = error.ToString();
 
-                var result = output.ToString();
-                var errorOutput = error.ToString();
+            Console.WriteLine("Cloud Example Output:");
+            Console.WriteLine(result);
 
-                Console.WriteLine("Cloud Example Output:");
-                Console.WriteLine(result);
-
-                if (!string.IsNullOrEmpty(errorOutput))
-                {
-                    Console.WriteLine("Cloud Example Error Output:");
-                    Console.WriteLine(errorOutput);
-                }
-
-                Assert.AreEqual(0, process.ExitCode,
-                    $"Cloud example should exit successfully. Error output: {errorOutput}");
-
-                Assert.Contains("Input values:", result,
-                    "Output should contain input values section");
-                Assert.Contains("Results:", result,
-                    "Output should contain results section");
-
-                Assert.IsTrue(networkNames.Any(x => result.Contains(x)),
-                    $"Output should contain {networkNames[0]} as registered name");
-                Assert.IsTrue(countryNames.Any(x => result.Contains(x)),
-                    $"Output should contain {countryNames[0]} as country or code");
-                Assert.IsTrue(ipRanges.Any(x => result.Contains(x)),
-                    $"Output should contain IP range values {rangeDescriptor}");
-
-                Assert.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(result, @"\d+\.\d+\.\d+\.\d+"),
-                    "Output should contain IP address values in dotted decimal format");
-
-                Assert.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(result, @"[\d\-]\d+\.\d+"),
-                    "Output should contain numeric values (coordinates, ranges, etc.)");
-
-                Assert.DoesNotContain("Exception", result,
-                    "Output should not contain exceptions");
-                Assert.DoesNotContain("Error", result,
-                    "Output should not contain errors");
+            if (!string.IsNullOrEmpty(errorOutput))
+            {
+                Console.WriteLine("Cloud Example Error Output:");
+                Console.WriteLine(errorOutput);
             }
+
+            return (process.ExitCode, result, errorOutput);
         }
     }
 }

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudMixedWebExample.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudMixedWebExample.cs
@@ -51,7 +51,11 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud;
 /// string, this test asserts the page renders successfully with the expected 
 /// structure rather than a specific geographic result.
 /// </remarks>
+// The web example tests all bind the same localhost port and switch the
+// process-wide current directory, so they cannot run in parallel with
+// each other.
 [TestClass]
+[DoNotParallelize]
 public class TestCloudMixedWebExample
 {
     // The example binds Constants.AllUrls; this is its plain-HTTP endpoint,

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudMixedWebExample.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudMixedWebExample.cs
@@ -1,0 +1,173 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+
+// Ignore Spelling: ip
+
+using FiftyOne.IpIntelligence.Examples;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WebProgram = FiftyOne.IpIntelligence.Examples.Mixed.Cloud.GettingStartedWeb.Program;
+
+namespace FiftyOne.IpIntelligence.Example.Tests.Cloud;
+
+/// <summary>
+/// Runs the combined (device detection + IP intelligence) Cloud
+/// GettingStarted-Web example in-process against the real 51Degrees Cloud
+/// service, then drives it over HTTP
+///exactly as a browser would and asserts the rendered page contains the
+/// combined-results layout.
+/// </summary>
+/// <remarks>
+/// Requires the <c>51DEGREES_RESOURCE_KEY</c> environment variable to be set. 
+/// As with the other web example tests it binds the example's configured 
+/// HTTP/HTTPS endpoints on start-up, so a trusted HTTPS development 
+/// certificate must be present. The page is queried over plain HTTP, because
+/// the example reads the visitor's IP from the connection rather than a query
+/// string, this test asserts the page renders successfully with the expected 
+/// structure rather than a specific geographic result.
+/// </remarks>
+[TestClass]
+public class TestCloudMixedWebExample
+{
+    // The example binds Constants.AllUrls; this is its plain-HTTP endpoint,
+    // which is the one we query (avoiding the HTTPS ports keeps the request
+    // side certificate-free).
+    private const string BaseUrl = "http://localhost:5101";
+
+    private static readonly string RepoRootPath =
+        Path.GetFullPath(
+            Path.GetDirectoryName(
+                ExampleUtils.FindFile("FiftyOne.IpIntelligence.Examples.sln"))!);
+
+    private static readonly string WebExampleDir =
+        Path.Combine(RepoRootPath, "Examples", "Cloud", "Mixed", "GettingStarted-Web");
+
+    private string _originalCurrentDirectory;
+    private CancellationTokenSource _cts;
+    private Task _serverTask;
+
+    [TestInitialize]
+    public void Init()
+    {
+        var resourceKey = ExampleUtils.GetResourceKeyFromEnv();
+
+        Assert.IsFalse(
+            string.IsNullOrWhiteSpace(resourceKey),
+            $"Environment variable '{ExampleUtils.CLOUD_RESOURCE_KEY_ENV_VAR}' " +
+            $"is not set. Obtain a resource key at " +
+            $"https://configure.51degrees.com and export it to run this test.");
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        _cts?.Cancel();
+        if (_serverTask != null)
+        {
+            // Swallow the expected cancellation; any other fault has already
+            // been surfaced by the test body.
+            try { await _serverTask; }
+            catch (OperationCanceledException) { }
+            catch { /* surfaced in the test */ }
+        }
+        if (_originalCurrentDirectory != null)
+        {
+            Directory.SetCurrentDirectory(_originalCurrentDirectory);
+        }
+        _cts?.Dispose();
+    }
+
+    /// <summary>
+    /// The combined web example should serve its results page with both the
+    /// device detection and IP intelligence sections rendered.
+    /// </summary>
+    [TestMethod]
+    public async Task Example_Cloud_MixedGettingStartedWeb()
+    {
+        // The example reads appsettings_51.json and locates its Razor views
+        // relative to the current directory, so host it from its own folder.
+        _originalCurrentDirectory = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(WebExampleDir);
+
+        _cts = new CancellationTokenSource();
+        _serverTask = WebProgram.Run([], _cts.Token);
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        await WaitUntilListeningAsync(client, TimeSpan.FromSeconds(30));
+
+        using var response = await client.GetAsync(BaseUrl, TestContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+            "The combined web example should return a 200 response.");
+
+        var html = await response.Content.ReadAsStringAsync(TestContext.CancellationToken);
+
+        Assert.Contains("Combined device detection and IP intelligence example", html,
+            "Page should render the combined example heading.");
+        Assert.Contains("IP intelligence results", html,
+            "Page should contain the IP intelligence results section.");
+        Assert.Contains("Device detection results", html,
+            "Page should contain the device detection results section.");
+    }
+
+    /// <summary>
+    /// Poll the example's HTTP endpoint until it serves a response, failing
+    /// loudly if the server faults on start-up or does not come up within 
+    /// <paramref name="timeout"/>.
+    /// </summary>
+    private async Task WaitUntilListeningAsync(HttpClient client, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            // If the host failed to start (e.g. a missing HTTPS dev
+            // certificate), await it so the real exception is thrown rather
+            // than letting the test time out with a generic message.
+            if (_serverTask.IsCompleted)
+            {
+                await _serverTask;
+            }
+
+            try
+            {
+                using var response = await client.GetAsync(BaseUrl, TestContext.CancellationToken);
+                return;
+            }
+            catch (HttpRequestException)
+            {
+                // Server not accepting connections yet - retry.
+                await Task.Delay(250, TestContext.CancellationToken);
+            }
+        }
+
+        Assert.Fail(
+            $"The Mixed GettingStarted-Web example did not start listening on " +
+            $"{BaseUrl} within {timeout.TotalSeconds:0} seconds.");
+    }
+
+    public TestContext TestContext { get; set; }
+}

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.Cloud/TestCloudWebExample.cs
@@ -51,7 +51,11 @@ namespace FiftyOne.IpIntelligence.Example.Tests.Cloud
     /// relative to the current directory, so the test runs it from the
     /// example's own directory.
     /// </remarks>
+    // The web example tests all bind the same localhost port and switch the
+    // process-wide current directory, so they cannot run in parallel with
+    // each other.
     [TestClass]
+    [DoNotParallelize]
     public class TestCloudWebExample
     {
         // A public IPv4 address known to resolve to the United Kingdom - the

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/FiftyOne.IpIntelligence.Example.Tests.OnPremise.csproj
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/FiftyOne.IpIntelligence.Example.Tests.OnPremise.csproj
@@ -38,6 +38,8 @@
     <ProjectReference Include="..\..\Examples\OnPremise\UpdateDataFile-Console\UpdateDataFile-Console.csproj" />
     <ProjectReference Include="..\..\Examples\OnPremise\Compare-Console\Compare-Console.csproj" />
     <ProjectReference Include="..\..\Examples\OnPremise\Suspicious-Console\Suspicious-Console.csproj" />
+    <ProjectReference Include="..\..\Examples\OnPremise\Performance-Console\Performance-Console.csproj" />
+    <ProjectReference Include="..\..\Examples\OnPremise\Mixed\GettingStarted-Console\GettingStarted-Console.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
+++ b/Tests/FiftyOne.IpIntelligence.Example.Tests.OnPremise/TestExamples.cs
@@ -27,7 +27,9 @@ using FiftyOne.IpIntelligence.Examples;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -391,6 +393,105 @@ public class TestExamples
                 "specified in the TestHashExamples.Init method or by setting an Environment " +
                 $"variable called '{Constants.LICENSE_KEY_ENV_VAR}'");
         }
+    }
+
+    /// <summary>
+    /// Test the Performance Example.
+    /// Runs the benchmark over a tiny, self-contained evidence set on a single
+    /// thread (just enough to prove the example executes and produces results,
+    /// without turning the test into a real performance run) and asserts the
+    /// returned benchmark results show detections were processed.
+    /// </summary>
+    [TestMethod]
+    public void Example_OnPremise_Performance()
+    {
+        VerifyDataFileAvailable();
+
+        var evidenceFile = WriteTempEvidenceYaml(
+            "82.12.34.23",
+            "116.154.188.222",
+            "8.8.8.8");
+        List<Examples.OnPremise.Performance.Program.BenchmarkResult> results = null;
+        try
+        {
+            // LowMemory is the only profile the example benchmarks (the data
+            // file must never be loaded entirely into memory); request only a
+            // single property to keep the run light.
+            var config = new Examples.OnPremise.Performance.PerformanceConfiguration(
+                FiftyOne.Pipeline.Engines.PerformanceProfiles.LowMemory, false);
+            RunResilient(() =>
+                results = Examples.OnPremise.Performance.Program.Example.Run(
+                    DataFile, evidenceFile, config, OutputWriter, (ushort)1));
+        }
+        finally
+        {
+            File.Delete(evidenceFile);
+        }
+
+        Assert.IsNotNull(results,
+            "Performance example should return benchmark results.");
+        Assert.IsGreaterThan(0, results.Count,
+            "Performance example should return at least one benchmark result.");
+        Assert.IsGreaterThan(0, results.Sum(r => r.Count),
+            "Performance example should have processed at least one detection.");
+    }
+
+    /// <summary>
+    /// Test the combined (device detection + IP intelligence) GettingStarted
+    /// Example. This additionally requires a device detection data file; when
+    /// one is not available the test reports inconclusive (rather than failing)
+    /// so the gap is visible without masquerading as a regression.
+    /// </summary>
+    [TestMethod]
+    public void Example_OnPremise_MixedGettingStarted()
+    {
+        VerifyDataFileAvailable();
+
+        var deviceDataFile = FindDeviceDataFile();
+        if (string.IsNullOrWhiteSpace(deviceDataFile) ||
+            File.Exists(deviceDataFile) == false)
+        {
+            Assert.Inconclusive(
+                "The combined example also requires a device detection data file " +
+                "(one of " +
+                $"'{string.Join("', '", Examples.Mixed.OnPremise.GettingStartedConsole.Constants.HASH_FILE_NAMES)}'). " +
+                "It was not found. Supply it (CI fetches it as an asset) to run " +
+                "this test.");
+        }
+
+        var example =
+            new Examples.Mixed.OnPremise.GettingStartedConsole.Program.Example();
+        RunResilient(() =>
+            example.Run(deviceDataFile, DataFile, new LoggerFactory(), OutputWriter));
+
+        var output = OutputString.ToString();
+        Assert.Contains("Input values:", output,
+            "Combined output should echo the input evidence.");
+        Assert.Contains("Device Detection Results:", output,
+            "Combined output should contain the device detection section.");
+        Assert.Contains("IP Intelligence Results:", output,
+            "Combined output should contain the IP intelligence section.");
+        Assert.Contains("62.61.32.31", output,
+            "Combined output should echo back the IPv4 evidence it analyses.");
+    }
+
+    /// <summary>
+    /// Locate a device detection data file using the same candidate file names
+    /// and search the combined example itself uses. Returns null when none can
+    /// be found.
+    /// </summary>
+    private static string FindDeviceDataFile()
+    {
+        foreach (var fileName in
+            Examples.Mixed.OnPremise.GettingStartedConsole.Constants.HASH_FILE_NAMES)
+        {
+            var path = ExampleUtils.FindFile(fileName);
+            if (string.IsNullOrWhiteSpace(path) == false)
+            {
+                return path;
+            }
+        }
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #126 

## Summary

Improves automated test coverage of the example projects, speeds up the
on-premise Metadata example, and documents the examples that cannot currently be
covered by an automated test.

**New tests (5 previously-untested examples):**
- Cloud `GetAllProperties-Console` and `Metadata-Console`, run as a subprocess
  via the existing `TestCloudExamples` pattern. The shared process plumbing was
  extracted into a `RunCloudExampleProcess` helper used by the existing and new
  console tests.
- Cloud `Mixed/GettingStarted-Web`, hosted in-process and driven over HTTP like
  `TestCloudWebExample`.
- OnPremise `Performance-Console` and `Mixed/GettingStarted-Console`, invoked
  in-process via `Example.Run` like the other `TestExamples` cases.

**Metadata example fix:**
- `OutputProfileDetails` enumerated every profile in the data file to print
  per-component counts. An enterprise IP Intelligence file holds tens of millions
  of profiles exposed as a forward-only stream with no cheap count, so this took
  over ten minutes. It now counts up to a bounded limit and reports lower bounds
  when the limit is reached. The on-premise test suite drops from roughly 21
  minutes to under 1 minute as a result.

## Changes

21 examples (the three `FiftyOne.IpIntelligence.Examples*` projects are shared
libraries, not examples). Coverage goes from 12 to 17. The remaining 4 are
documented in the README:

- `Cloud/Framework-Web` and `OnPremise/Framework-Web` are legacy .NET Framework
  4.6.2 apps, outside the net10.0 cross-platform CI harness, so they are verified
  by compilation only.
- `OnPremise/GettingStarted-Web` and `OnPremise/Mixed/GettingStarted-Web` run
  correctly standalone but cannot be hosted in-process from the test project,
  because their relative-data-file config override corrupts the pipeline element
  configuration under the test host. They are verified manually with `dotnet run`
  pending a follow-up fix.